### PR TITLE
Performance optimizations and profiling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ SpacesInAngles: false
 SpacesInParentheses: false
 
 # --- Alignment ---
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 
@@ -35,6 +35,7 @@ ReferenceAlignment: Left
 ColumnLimit: 100
 BinPackArguments: false
 BinPackParameters: false
+AllowAllArgumentsOnNextLine: false
 
 # --- Functions & Lambdas ---
 AllowShortFunctionsOnASingleLine: Inline

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,8 @@ Checks: >
   -cppcoreguidelines-pro-type-union-access,
   -readability-magic-numbers,
   -cppcoreguidelines-avoid-magic-numbers,
-  -bugprone-easily-swappable-parameters
+  -bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-pro-bounds-constant-array-index
 # -readability-convert-member-functions-to-static,
 # -performance-enum-size
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ logs/
 notes/
 reference/
 Testing/
+perf/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Add profiling module to analyze performance bottlenecks and measure frame times.
+  - Profiler based on regular and scoped timers: `Profiler`, `Timer`, `ScopedTimer`.
+  - Hot profiler for critical and high-frequency code sections: `HotProfiler`.
+  - Frame profiler to measure frame times and FPS: `FrameProfiler`.
+  - Profiling API with optional macros: `profiler_utils.h`.
+  - Conditional compilation with `ENABLE_PROFILING` CMake option.
+
+### Changed
+
+- Refactor `Emulator` and more specifically the emulation loop
+  - Frame-based emulation loop
+  - Move `Display::poll_events` to start of each frame instead of calling every step
+  - Replace FPS/IPS/CPS counter in `emulator.cpp` for `FrameProfiler`
+- Replace `Mmu` loop-based region finding for O(1) lookup table and other optimizations
+
 ## [0.3.0] - 2025-10-04
 
 ### Added
@@ -79,7 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Set up CMake build system with presets.
 - Unit and integration tests for CPU instructions, interrupts, MMU, ROM loading, and I/O registers.
 
-[Unreleased]: https://github.com/sebdevnull/boyboy/compare/v0.3.0...develop
+[Unreleased]: https://github.com/sebdevnull/boyboy/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/sebdevnull/boyboy/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/sebdevnull/boyboy/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/sebdevnull/boyboy/releases/tag/v0.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,12 @@ if(DISASSEMBLY_LOG)
     add_compile_definitions(DISASSEMBLY_LOG)
 endif()
 
+option(ENABLE_PROFILING "Enable profiling" OFF)
+if(ENABLE_PROFILING)
+    message(NOTICE "[INFO] Profiling enabled")
+    add_compile_definitions(ENABLE_PROFILING)
+endif()
+
 # --- Library target ---
 add_library(${BOYBOY_LIB} STATIC)
 target_sources(${BOYBOY_LIB} PRIVATE

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,8 +36,7 @@
                 "TEST_CPU_STUBS": "ON",
                 "BOYBOY_DEBUG": "ON",
                 "LOG_LEVEL": "DEBUG",
-                "DISASSEMBLY_LOG": "OFF",
-                "ENABLE_PROFILING": "ON"
+                "DISASSEMBLY_LOG": "OFF"
             }
         },
         {
@@ -157,6 +156,11 @@
             "inherits": "default"
         },
         {
+            "name": "debug-profiling",
+            "configurePreset": "debug-profiling",
+            "inherits": "default"
+        },
+        {
             "name": "release-symbols",
             "configurePreset": "release-symbols",
             "inherits": "default"
@@ -164,6 +168,11 @@
         {
             "name": "release-no-tests",
             "configurePreset": "release-no-tests",
+            "inherits": "default"
+        },
+        {
+            "name": "release-profiling",
+            "configurePreset": "release-profiling",
             "inherits": "default"
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,7 +20,8 @@
                 "BUILD_TESTING": "ON",
                 "ENABLE_CLANG_TIDY": "OFF",
                 "LOG_LEVEL": "INFO",
-                "DISASSEMBLY_LOG": "OFF"
+                "DISASSEMBLY_LOG": "OFF",
+                "ENABLE_PROFILING": "OFF"
             }
         },
         {
@@ -35,7 +36,8 @@
                 "TEST_CPU_STUBS": "ON",
                 "BOYBOY_DEBUG": "ON",
                 "LOG_LEVEL": "DEBUG",
-                "DISASSEMBLY_LOG": "OFF"
+                "DISASSEMBLY_LOG": "OFF",
+                "ENABLE_PROFILING": "ON"
             }
         },
         {
@@ -75,22 +77,32 @@
             }
         },
         {
+            "name": "debug-optimized",
+            "inherits": "debug",
+            "description": "Debug with optimizations (-Og -g)",
+            "cacheVariables": {
+                "ENABLE_PROFILING": "ON",
+                "ENABLE_SANITIZERS": "OFF",
+                "BUILD_TESTING": "OFF",
+                "CMAKE_CXX_FLAGS_DEBUG": "-Og -g -Wall -Wextra -Wpedantic -DDEBUG"
+            }
+        },
+        {
             "name": "release-symbols",
             "inherits": "release",
             "description": "Release with debug symbols (-O2 -g)",
             "cacheVariables": {
+                "ENABLE_PROFILING": "ON",
                 "BUILD_TESTING": "OFF",
                 "CMAKE_FLAGS_RELEASE": "-O2 -g -DNDEBUG"
             }
         },
         {
-            "name": "debug-optimized",
-            "inherits": "debug",
-            "description": "Debug with optimizations (-Og -g)",
+            "name": "release-no-tests",
+            "inherits": "release",
+            "description": "Release configuration without tests",
             "cacheVariables": {
-                "ENABLE_SANITIZERS": "OFF",
-                "BUILD_TESTING": "OFF",
-                "CMAKE_CXX_FLAGS_DEBUG": "-Og -g -Wall -Wextra -Wpedantic -DDEBUG"
+                "BUILD_TESTING": "OFF"
             }
         }
     ],
@@ -126,13 +138,18 @@
             "inherits": "default"
         },
         {
+            "name": "debug-optimized",
+            "configurePreset": "debug-optimized",
+            "inherits": "default"
+        },
+        {
             "name": "release-symbols",
             "configurePreset": "release-symbols",
             "inherits": "default"
         },
         {
-            "name": "debug-optimized",
-            "configurePreset": "debug-optimized",
+            "name": "release-no-tests",
+            "configurePreset": "release-no-tests",
             "inherits": "default"
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,10 +81,17 @@
             "inherits": "debug",
             "description": "Debug with optimizations (-Og -g)",
             "cacheVariables": {
-                "ENABLE_PROFILING": "ON",
                 "ENABLE_SANITIZERS": "OFF",
                 "BUILD_TESTING": "OFF",
                 "CMAKE_CXX_FLAGS_DEBUG": "-Og -g -Wall -Wextra -Wpedantic -DDEBUG"
+            }
+        },
+        {
+            "name": "debug-profiling",
+            "inherits": "debug-optimized",
+            "description": "Debug with optimizations and profiling enabled",
+            "cacheVariables": {
+                "ENABLE_PROFILING": "ON"
             }
         },
         {
@@ -92,7 +99,6 @@
             "inherits": "release",
             "description": "Release with debug symbols (-O2 -g)",
             "cacheVariables": {
-                "ENABLE_PROFILING": "ON",
                 "BUILD_TESTING": "OFF",
                 "CMAKE_FLAGS_RELEASE": "-O2 -g -DNDEBUG"
             }
@@ -103,6 +109,14 @@
             "description": "Release configuration without tests",
             "cacheVariables": {
                 "BUILD_TESTING": "OFF"
+            }
+        },
+        {
+            "name": "release-profiling",
+            "inherits": "release-symbols",
+            "description": "Release with debug symbols and profiling enabled",
+            "cacheVariables": {
+                "ENABLE_PROFILING": "ON"
             }
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -73,6 +73,25 @@
                 "ENABLE_CLANG_TIDY": "ON",
                 "BUILD_TESTING": "ON"
             }
+        },
+        {
+            "name": "release-symbols",
+            "inherits": "release",
+            "description": "Release with debug symbols (-O2 -g)",
+            "cacheVariables": {
+                "BUILD_TESTING": "OFF",
+                "CMAKE_FLAGS_RELEASE": "-O2 -g -DNDEBUG"
+            }
+        },
+        {
+            "name": "debug-optimized",
+            "inherits": "debug",
+            "description": "Debug with optimizations (-Og -g)",
+            "cacheVariables": {
+                "ENABLE_SANITIZERS": "OFF",
+                "BUILD_TESTING": "OFF",
+                "CMAKE_CXX_FLAGS_DEBUG": "-Og -g -Wall -Wextra -Wpedantic -DDEBUG"
+            }
         }
     ],
     "buildPresets": [
@@ -104,6 +123,16 @@
         {
             "name": "debug-tidy-tests",
             "configurePreset": "debug-tidy-tests",
+            "inherits": "default"
+        },
+        {
+            "name": "release-symbols",
+            "configurePreset": "release-symbols",
+            "inherits": "default"
+        },
+        {
+            "name": "debug-optimized",
+            "configurePreset": "debug-optimized",
             "inherits": "default"
         }
     ],

--- a/include/boyboy/cpu/cpu_constants.h
+++ b/include/boyboy/cpu/cpu_constants.h
@@ -23,4 +23,7 @@ constexpr uint8_t CBInstructionPrefix = 0xCB;
 
 constexpr uint16_t HighRAMOffset = 0xFF00;
 
+constexpr uint64_t MasterClockFrequencyHz = 4'194'304;                  // 4.194304 MHz
+constexpr uint64_t SystemClockFrequencyHz = MasterClockFrequencyHz / 4; // 1.048576 MHz
+
 } // namespace boyboy::cpu

--- a/include/boyboy/emulator.h
+++ b/include/boyboy/emulator.h
@@ -24,14 +24,19 @@ public:
 
     // Emulator operations
     void load(const std::string& path);
-    void step();
+    void start();
+    void stop();
     void run();
     void reset();
 
+    // State accessors
+    [[nodiscard]] bool is_running() const { return running_; }
+    [[nodiscard]] bool is_started() const { return started_; }
+    void limit_frame_rate(bool limit) { frame_rate_limited_ = limit; }
+    [[nodiscard]] bool is_frame_rate_limited() const { return frame_rate_limited_; }
+
     // Button event handler
     void on_button_event(io::Button button, bool pressed);
-
-    [[nodiscard]] const display::Display& get_display() const { return display_; }
 
 private:
     // System components
@@ -45,10 +50,15 @@ private:
 
     // Emulator state
     bool running_ = false;
+    bool started_ = false;
+    bool frame_rate_limited_ = true;
 
     // Statistics
     uint64_t instruction_count_ = 0;
     uint64_t cycle_count_ = 0;
+
+    void emulate_frame();
+    void render_frame();
 };
 
 } // namespace boyboy::emulator

--- a/include/boyboy/emulator.h
+++ b/include/boyboy/emulator.h
@@ -47,9 +47,8 @@ private:
     bool running_ = false;
 
     // Statistics
-    double frame_count_ = 0;
-    double instruction_count_ = 0;
-    double cycle_count_ = 0;
+    uint64_t instruction_count_ = 0;
+    uint64_t cycle_count_ = 0;
 };
 
 } // namespace boyboy::emulator

--- a/include/boyboy/mmu/constants.h
+++ b/include/boyboy/mmu/constants.h
@@ -13,6 +13,8 @@
 namespace boyboy::mmu {
 
 // --- MMU memory map constants ---
+static constexpr uint32_t MemoryMapSize = (1 << 16); // 16-bit address space (64KB)
+
 static constexpr uint16_t ROMBank0Start = 0x0000;
 static constexpr uint16_t ROMBank0End = 0x3FFF;
 static constexpr uint16_t ROMBank1Start = 0x4000;

--- a/include/boyboy/ppu/ppu.h
+++ b/include/boyboy/ppu/ppu.h
@@ -13,6 +13,7 @@
 #include <ostream>
 
 #include "boyboy/common/utils.h"
+#include "boyboy/cpu/cpu_constants.h"
 #include "boyboy/io/iocomponent.h"
 #include "boyboy/io/registers.h"
 #include "boyboy/ppu/palettes.h"
@@ -73,6 +74,11 @@ static constexpr int TotalScanlines = VisibleScanlines + VBlankScanlines;
 static constexpr uint32_t CyclesPerFrame =
     ((Cycles::OAMScan + Cycles::Transfer + Cycles::HBlank) * VisibleScanlines) +
     (Cycles::VBlank * VBlankScanlines);
+
+// Frame rate (approx 59.73 Hz)
+static constexpr double FrameRate =
+    static_cast<double>(cpu::MasterClockFrequencyHz) / CyclesPerFrame; // Hz
+static constexpr double FrameDuration = 1.0 / FrameRate;               // seconds
 
 // Types definitions
 using Pixel = uint32_t; // RGBA format

--- a/include/boyboy/profiling/frame_profiler.h
+++ b/include/boyboy/profiling/frame_profiler.h
@@ -214,9 +214,9 @@ public:
             }
         }
 
-        log::info("----- Frame Profiling Report -----");
+        log::info("----- Frame Profiler Report -----");
         log::info("{}", log_msg);
-        log::info("----------------------------------");
+        log::info("---------------------------------");
     }
 
     /**

--- a/include/boyboy/profiling/frame_profiler.h
+++ b/include/boyboy/profiling/frame_profiler.h
@@ -1,0 +1,268 @@
+/**
+ * @file frame_profiler.h
+ * @brief Frame profiler for measuring FPS and performance metrics.
+ *
+ * Provides types and a class for collecting and reporting frame-based statistics,
+ * such as FPS, IPS, CPS, and per-component timing.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <format>
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "boyboy/log/logging.h"
+
+namespace boyboy::profiling {
+
+/**
+ * @brief Enum for core frame timing components.
+ */
+enum class FrameTimer : uint8_t { Cpu, Ppu, Render, Count };
+
+/**
+ * @brief Convert FrameTimer enum to string.
+ * @param timer FrameTimer value.
+ * @return String representation.
+ */
+inline std::string to_string(FrameTimer timer)
+{
+    switch (timer) {
+    case FrameTimer::Cpu:
+        return "Cpu";
+    case FrameTimer::Ppu:
+        return "Ppu";
+    case FrameTimer::Render:
+        return "Render";
+    default:
+        return "Unknown";
+    }
+}
+
+/**
+ * @brief Array of per-component timing values (in microseconds).
+ */
+using FrameTimes = std::array<uint64_t, static_cast<size_t>(FrameTimer::Count)>;
+
+/**
+ * @brief Aggregate two FrameTimes arrays element-wise.
+ * @param lhs Left-hand side (accumulated).
+ * @param rhs Right-hand side (to add).
+ * @return Reference to lhs.
+ */
+inline FrameTimes& operator+=(FrameTimes& lhs, const FrameTimes& rhs)
+{
+    std::ranges::transform(lhs, rhs, lhs.begin(), std::plus<>{});
+    return lhs;
+}
+
+/**
+ * @brief Per-frame data: instruction/cycle counts and optional timing.
+ */
+struct FrameData {
+    uint64_t instruction_count{0};
+    uint64_t cycle_count{0};
+    std::optional<FrameTimes> times_us;
+
+    /**
+     * @brief Aggregate another FrameData into this one.
+     * @param other FrameData to add.
+     * @return Reference to this.
+     */
+    FrameData& operator+=(const FrameData& other)
+    {
+        instruction_count += other.instruction_count;
+        cycle_count += other.cycle_count;
+        if (other.times_us) {
+            if (!times_us) {
+                times_us.emplace();
+            }
+            *times_us += *other.times_us;
+        }
+        return *this;
+    }
+
+    /**
+     * @brief Reset all counts to zero (and timing if present).
+     */
+    void reset()
+    {
+        instruction_count = 0;
+        cycle_count = 0;
+        if (times_us) {
+            times_us.emplace();
+        }
+    }
+};
+
+/**
+ * @brief Accumulated stats for a set of frames (interval or total).
+ */
+struct RunningStats {
+    uint64_t frame_count{0};
+    FrameData frame_data;
+
+    /**
+     * @brief Aggregate another RunningStats into this one.
+     * @param other Stats to add.
+     * @return Reference to this.
+     */
+    RunningStats& operator+=(const RunningStats& other)
+    {
+        frame_count += other.frame_count;
+        frame_data += other.frame_data;
+        return *this;
+    }
+
+    /**
+     * @brief Reset all stats to zero.
+     */
+    void reset()
+    {
+        frame_count = 0;
+        frame_data.reset();
+    }
+};
+
+/**
+ * @brief FrameProfiler collects and reports frame-based statistics.
+ *
+ * Tracks FPS, IPS, CPS, and per-component timing, with periodic and total reporting.
+ */
+class FrameProfiler {
+public:
+    /**
+     * @brief Construct a FrameProfiler.
+     * @param log_interval Interval (in seconds) for periodic logging.
+     */
+    FrameProfiler(double log_interval = 1.0)
+        : log_interval_(log_interval), last_log_time_(std::chrono::high_resolution_clock::now()),
+          start_time_(last_log_time_)
+    {
+    }
+
+    /**
+     * @brief Get total accumulated stats.
+     * @return Reference to total RunningStats.
+     */
+    [[nodiscard]] const RunningStats& total_stats() const { return total_stats_; }
+
+    /**
+     * @brief Set the periodic log interval (in seconds).
+     * @param interval Log interval in seconds.
+     */
+    void set_log_interval(double interval) { log_interval_ = interval; }
+
+    /**
+     * @brief Record a new frame's data.
+     * @param frame_data Data for the frame.
+     */
+    void record_frame(const FrameData& frame_data)
+    {
+        frame_stats_.frame_count++;
+        frame_stats_.frame_data += frame_data;
+
+        auto now = std::chrono::high_resolution_clock::now();
+        double elapsed = std::chrono::duration<double>(now - last_log_time_).count();
+
+        if (elapsed > log_interval_) {
+            log_frame(elapsed);
+            last_log_time_ = now;
+            flush();
+        }
+    }
+
+    /**
+     * @brief Output a final report of all accumulated stats.
+     *
+     * Flushes any pending interval data before reporting.
+     */
+    void report()
+    {
+        flush(); // Ensure all interval data is included
+
+        auto now = std::chrono::high_resolution_clock::now();
+        double total_elapsed = std::chrono::duration<double>(now - start_time_).count();
+
+        const auto& frame_data = total_stats_.frame_data;
+
+        double avg_fps = static_cast<double>(total_stats_.frame_count) / total_elapsed;
+        double avg_ips = static_cast<double>(frame_data.instruction_count) / total_elapsed;
+        double avg_cps = static_cast<double>(frame_data.cycle_count) / total_elapsed;
+
+        std::string log_msg =
+            std::format("Frames: {} | Avg FPS: {:.1f} | Avg IPS: {:.1f}k | Avg CPS: {:.1f}k",
+                        total_stats_.frame_count,
+                        avg_fps,
+                        avg_ips / 1e3,
+                        avg_cps / 1e3);
+
+        // Component timing averaged per frame
+        if (frame_data.times_us) {
+            for (size_t i = 0; i < static_cast<size_t>(FrameTimer::Count); ++i) {
+                double avg_time = static_cast<double>((*frame_data.times_us).at(i)) /
+                                  static_cast<double>(total_stats_.frame_count);
+                log_msg += std::format(
+                    " | Avg {}: {:.1f}us", to_string(static_cast<FrameTimer>(i)), avg_time);
+            }
+        }
+
+        log::info("----- Frame Profiling Report -----");
+        log::info("{}", log_msg);
+        log::info("----------------------------------");
+    }
+
+    /**
+     * @brief Flush current interval stats into totals and reset the interval.
+     */
+    void flush()
+    {
+        total_stats_ += frame_stats_;
+        frame_stats_.reset();
+    }
+
+private:
+    double log_interval_;
+    std::chrono::high_resolution_clock::time_point last_log_time_;
+    std::chrono::high_resolution_clock::time_point start_time_;
+
+    RunningStats frame_stats_{};
+    RunningStats total_stats_{};
+
+    /**
+     * @brief Log the current interval's stats.
+     * @param elapsed Elapsed time (in seconds) since last log.
+     */
+    void log_frame(double elapsed) const
+    {
+        const auto& frame_data = frame_stats_.frame_data;
+        double fps = static_cast<double>(frame_stats_.frame_count) / elapsed;
+        double ips = static_cast<double>(frame_data.instruction_count) / elapsed;
+        double cps = static_cast<double>(frame_data.cycle_count) / elapsed;
+
+        // Compose log message
+        std::string log_msg =
+            std::format("FPS: {:.1f} | IPS: {:.1f}k | CPS: {:.1f}k", fps, ips / 1e3, cps / 1e3);
+
+        // Compose timing breakdown if available
+        if (frame_data.times_us) {
+            for (size_t i = 0; i < static_cast<size_t>(FrameTimer::Count); ++i) {
+                double avg_time = static_cast<double>((*frame_data.times_us).at(i)) /
+                                  static_cast<double>(frame_stats_.frame_count);
+                log_msg +=
+                    std::format(" | {}: {:.1f}us", to_string(static_cast<FrameTimer>(i)), avg_time);
+            }
+        }
+
+        log::info("{}", log_msg);
+    }
+};
+
+} // namespace boyboy::profiling

--- a/include/boyboy/profiling/hot_profiler.h
+++ b/include/boyboy/profiling/hot_profiler.h
@@ -1,0 +1,122 @@
+/**
+ * @file hot_profiler.h
+ * @brief High-performance profiler for hot code sections.
+ *
+ * Provides a lightweight, allocation-free profiler for measuring execution time and call counts of
+ * fixed, high-frequency code sections.
+ * Uses enum-based section IDs for fast lookup and reporting.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+
+#include "boyboy/log/logging.h"
+
+namespace boyboy::profiling {
+
+/**
+ * @brief Enum for identifying hot code sections to be profiled.
+ *
+ * Each value corresponds to a specific subsystem or operation.
+ */
+enum class HotSection : uint8_t {
+    CpuFetch,
+    CpuExecute,
+    MmuRead,
+    MmuWrite,
+    MmuLookup,
+    Count,
+};
+
+/**
+ * @brief Convert a HotSection enum value to a string.
+ * @param section HotSection value.
+ * @return C-string representation of the section name.
+ */
+inline const char* to_string(HotSection section)
+{
+    switch (section) {
+    case HotSection::CpuFetch:
+        return "Cpu::fetch";
+    case HotSection::CpuExecute:
+        return "Cpu::execute";
+    case HotSection::MmuLookup:
+        return "Mmu::lookup";
+    case HotSection::MmuRead:
+        return "Mmu::read";
+    case HotSection::MmuWrite:
+        return "Mmu::write";
+    default:
+        return "Unknown";
+    }
+}
+
+/**
+ * @brief High-performance profiler for hot code sections.
+ *
+ * Tracks timing and call counts for a fixed set of code sections,
+ * using fast array-based storage indexed by HotSection.
+ */
+class HotProfiler {
+public:
+    using clock = std::chrono::high_resolution_clock;
+    using duration = std::chrono::nanoseconds;
+    using time_point = std::chrono::time_point<clock>;
+
+    /**
+     * @brief Start timing a hot section.
+     * @param section The HotSection to start timing.
+     */
+    void start(HotSection section) { start_times_[static_cast<size_t>(section)] = clock::now(); }
+
+    /**
+     * @brief Stop timing a hot section and accumulate the elapsed time.
+     * @param section The HotSection to stop timing.
+     */
+    void stop(HotSection section)
+    {
+        auto idx = static_cast<size_t>(section);
+        auto now = clock::now();
+        auto elapsed = std::chrono::duration_cast<duration>(now - start_times_[idx]);
+        accumulated_times_[idx] += elapsed;
+        call_counts_[idx]++;
+    }
+
+    /**
+     * @brief Output a profiling report for all hot sections.
+     *
+     * Prints total time, call count, and average time per call for each section.
+     */
+    void report()
+    {
+        log::info("----- Hot Profiler Report -----");
+        for (size_t i = 0; i < static_cast<size_t>(HotSection::Count); ++i) {
+            if (call_counts_[i] == 0) {
+                continue;
+            }
+            auto avg_time = static_cast<double>(accumulated_times_[i].count()) /
+                            static_cast<double>(call_counts_[i]);
+            log::info(
+                "[{}]: total={}ns, calls={}, avg={:.2f}ns",
+                to_string(static_cast<HotSection>(i)),
+                accumulated_times_[i].count(),
+                call_counts_[i],
+                avg_time
+            );
+        }
+        log::info("-------------------------------");
+    }
+
+private:
+    std::array<time_point, static_cast<size_t>(HotSection::Count)> start_times_{};
+    std::array<duration, static_cast<size_t>(HotSection::Count)> accumulated_times_{};
+    std::array<uint64_t, static_cast<size_t>(HotSection::Count)> call_counts_{};
+};
+
+} // namespace boyboy::profiling

--- a/include/boyboy/profiling/profiler.h
+++ b/include/boyboy/profiling/profiler.h
@@ -1,0 +1,110 @@
+/**
+ * @file profiler.h
+ * @brief Profiler utilities for the BoyBoy emulator.
+ *
+ * Provides interfaces and implementations for high-level profiling,
+ * including manual and scoped timing, and integration with the Timer API.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "boyboy/profiling/timer.h"
+
+namespace boyboy::profiling {
+
+/**
+ * @brief Abstract interface for a high-level profiler.
+ *
+ * Provides methods for starting/stopping timers, scoped (RAII) timing,
+ * reporting, and access to the underlying timer.
+ */
+class IProfiler {
+public:
+    IProfiler() = default;
+    IProfiler(const IProfiler&) = delete;
+    IProfiler& operator=(const IProfiler&) = delete;
+    IProfiler(IProfiler&&) = delete;
+    IProfiler& operator=(IProfiler&&) = delete;
+
+    virtual ~IProfiler() = default;
+
+    /**
+     * @brief Start timing a named code section.
+     * @param name Timer name.
+     */
+    virtual void start(const std::string& name) = 0;
+
+    /**
+     * @brief Stop timing a named code section.
+     * @param name Timer name.
+     */
+    virtual void stop(const std::string& name) = 0;
+
+    /**
+     * @brief Create a scoped timer for a named code section.
+     * @param name Timer name.
+     * @return Unique pointer to a scoped timer (RAII).
+     */
+    virtual std::unique_ptr<IScopedTimer> scoped(const std::string& name) = 0;
+
+    /**
+     * @brief Output a profiling report for all timers.
+     */
+    virtual void report() = 0;
+
+    /**
+     * @brief Access the underlying timer implementation.
+     * @return Reference to the timer.
+     */
+    virtual ITimer& timer() = 0;
+};
+
+/**
+ * @brief Concrete profiler implementation.
+ *
+ * Wraps a Timer and provides high-level profiling API.
+ */
+class Profiler : public IProfiler {
+public:
+    void start(const std::string& name) override { timer_.start(name); }
+    void stop(const std::string& name) override { timer_.stop(name); }
+
+    std::unique_ptr<IScopedTimer> scoped(const std::string& name) override
+    {
+        return std::make_unique<ScopedTimer>(timer_, name);
+    }
+
+    void report() override { timer_.report(); }
+
+    ITimer& timer() override { return timer_; }
+
+private:
+    Timer timer_;
+};
+
+/**
+ * @brief Null profiler implementation (no-op).
+ *
+ * Used when profiling is disabled.
+ */
+class NullProfiler : public IProfiler {
+public:
+    void start(const std::string& /*name*/) override {}
+    void stop(const std::string& /*name*/) override {}
+    std::unique_ptr<IScopedTimer> scoped(const std::string& /*name*/) override
+    {
+        return std::make_unique<NullScopedTimer>(null_timer_, "");
+    }
+    void report() override {}
+    ITimer& timer() override { return null_timer_; }
+
+private:
+    NullTimer null_timer_;
+};
+
+} // namespace boyboy::profiling

--- a/include/boyboy/profiling/profiler_utils.h
+++ b/include/boyboy/profiling/profiler_utils.h
@@ -1,0 +1,209 @@
+/**
+ * @file profiler_utils.h
+ * @brief Profiler utilities API for the BoyBoy emulator.
+ *
+ * Provides macros and inline functions for easy, conditional profiling and frame statistics.
+ * When ENABLE_PROFILING is not defined, all macros/functions become no-ops except for frame stats.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+#include "boyboy/profiling/frame_profiler.h"
+#include "boyboy/profiling/profiler.h"
+
+namespace boyboy::profiling {
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+/**
+ * @defgroup ProfilingMacros Profiling Macros
+ * @brief Macros for ergonomic profiling instrumentation.
+ * @{
+ */
+
+#ifdef ENABLE_PROFILING
+using ActiveProfiler = Profiler;
+
+/// Concatenate two tokens (internal macro).
+#define BB_CONCAT_IMPL(x, y) x##y
+/// Concatenate two tokens (user macro).
+#define BB_CONCAT(x, y) BB_CONCAT_IMPL(x, y)
+
+/**
+ * @brief Start a named profiling timer.
+ * @param name Timer name (string or FrameTimer enum).
+ */
+#define BB_PROFILE_START(name) boyboy::profiling::profile_start(name)
+
+/**
+ * @brief Stop a named profiling timer.
+ * @param name Timer name (string or FrameTimer enum).
+ */
+#define BB_PROFILE_STOP(name) boyboy::profiling::profile_stop(name)
+
+/**
+ * @brief Profile a scope using RAII. Automatically stops when leaving scope.
+ * @param name Timer name (string or FrameTimer enum).
+ */
+#define BB_PROFILE_SCOPE(name)                                                                     \
+    [[maybe_unused]] auto BB_CONCAT(_bb_profile_scope_, __LINE__) =                                \
+        boyboy::profiling::profile_scope(name)
+
+/**
+ * @brief Output a profiling report for all timers.
+ */
+#define BB_PROFILE_REPORT() boyboy::profiling::profile_report()
+#else
+using ActiveProfiler = NullProfiler;
+
+#define BB_PROFILE_START(name)
+#define BB_PROFILE_STOP(name)
+#define BB_PROFILE_REPORT()
+#define BB_PROFILE_SCOPE(name)
+#endif
+
+/**
+ * @brief Record per-frame statistics (instructions, cycles, and optionally timing data).
+ * @param instr Instruction count for the frame.
+ * @param cycles Cycle count for the frame.
+ */
+#define BB_PROFILE_FRAME(instr, cycles) boyboy::profiling::profile_frame(instr, cycles)
+
+/**
+ * @brief Output a frame profiler report (FPS, IPS, CPS, etc).
+ */
+#define BB_FRAME_PROFILE_REPORT() boyboy::profiling::frame_profile_report()
+
+/** @} */
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+/**
+ * @brief Get the global profiler instance.
+ * @return Reference to the active profiler (real or null).
+ */
+inline IProfiler& get_profiler()
+{
+    static ActiveProfiler profiler;
+    return profiler;
+}
+
+/**
+ * @brief Get the global frame profiler instance.
+ * @return Reference to the frame profiler.
+ */
+inline FrameProfiler& get_frame_profiler()
+{
+    static FrameProfiler frame_profiler;
+    return frame_profiler;
+}
+
+/**
+ * @brief Start a named profiling timer (string).
+ * @param name Timer name.
+ */
+inline void profile_start(const std::string& name)
+{
+    get_profiler().start(name);
+}
+
+/**
+ * @brief Start a named profiling timer (enum).
+ * @param timer FrameTimer enum value.
+ */
+inline void profile_start(FrameTimer timer)
+{
+    get_profiler().start(to_string(timer));
+}
+
+/**
+ * @brief Stop a named profiling timer (string).
+ * @param name Timer name.
+ */
+inline void profile_stop(const std::string& name)
+{
+    get_profiler().stop(name);
+}
+
+/**
+ * @brief Stop a named profiling timer (enum).
+ * @param timer FrameTimer enum value.
+ */
+inline void profile_stop(FrameTimer timer)
+{
+    get_profiler().stop(to_string(timer));
+}
+
+/**
+ * @brief Profile a scope using RAII (string).
+ * @param name Timer name.
+ * @return RAII object that stops the timer on destruction.
+ */
+inline auto profile_scope(const std::string& name)
+{
+    return get_profiler().scoped(name);
+}
+
+/**
+ * @brief Profile a scope using RAII (enum).
+ * @param timer FrameTimer enum value.
+ * @return RAII object that stops the timer on destruction.
+ */
+inline auto profile_scope(FrameTimer timer)
+{
+    return get_profiler().scoped(to_string(timer));
+}
+
+/**
+ * @brief Record per-frame statistics.
+ *
+ * Always records instruction and cycle counts. If profiling is enabled,
+ * also records per-frame timing deltas for each FrameTimer.
+ *
+ * @param instructions Instruction count for the frame.
+ * @param cycles Cycle count for the frame.
+ */
+inline void profile_frame(uint64_t instructions, uint64_t cycles)
+{
+    FrameData frame_data{};
+    frame_data.instruction_count = instructions;
+    frame_data.cycle_count = cycles;
+
+#ifdef ENABLE_PROFILING
+    // Store last times to calculate deltas to pass to FrameProfiler
+    static FrameTimes last_times{};
+
+    FrameTimes current_times;
+    for (size_t i = 0; i < static_cast<size_t>(FrameTimer::Count); ++i) {
+        current_times.at(i) =
+            get_profiler().timer().get_time_us(to_string(static_cast<FrameTimer>(i)));
+    }
+
+    FrameTimes deltas;
+    for (size_t i = 0; i < static_cast<size_t>(FrameTimer::Count); ++i) {
+        deltas.at(i) = current_times.at(i) - last_times.at(i);
+        last_times.at(i) = current_times.at(i);
+    }
+    frame_data.times_us = deltas;
+#endif
+
+    get_frame_profiler().record_frame(frame_data);
+}
+
+/**
+ * @brief Output a profiling report for all timers.
+ */
+inline void profile_report()
+{
+    get_profiler().report();
+}
+
+/**
+ * @brief Output a frame profiler report (FPS, IPS, CPS, etc).
+ */
+inline void frame_profile_report()
+{
+    get_frame_profiler().report();
+}
+
+} // namespace boyboy::profiling

--- a/include/boyboy/profiling/timer.h
+++ b/include/boyboy/profiling/timer.h
@@ -107,7 +107,7 @@ public:
         }
         std::ranges::sort(names);
 
-        log::info("---- Profiling Report ----");
+        log::info("----- Profiler Report -----");
         for (const auto& name : names) {
             uint64_t total_time = accumulated_times_[name];
             uint64_t count = call_counts_[name];
@@ -115,7 +115,7 @@ public:
             log::info(
                 "[{}]: total={}us, calls={}, avg={:.2f}us", name, total_time, count, avg_time);
         }
-        log::info("--------------------------");
+        log::info("---------------------------");
 
         start_times_.clear();
         accumulated_times_.clear();

--- a/include/boyboy/profiling/timer.h
+++ b/include/boyboy/profiling/timer.h
@@ -1,0 +1,209 @@
+/**
+ * @file timer.h
+ * @brief Timer utility for profiling code execution time.
+ *
+ * Provides interfaces and implementations for timing named code sections,
+ * supporting both manual and RAII-based (scoped) timing.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "boyboy/log/logging.h"
+
+namespace boyboy::profiling {
+
+/**
+ * @brief Abstract interface for a profiling timer.
+ */
+class ITimer {
+public:
+    ITimer() = default;
+    ITimer(const ITimer&) = delete;
+    ITimer& operator=(const ITimer&) = delete;
+    ITimer(ITimer&&) = delete;
+    ITimer& operator=(ITimer&&) = delete;
+    virtual ~ITimer() = default;
+
+    /**
+     * @brief Start timing a named code section.
+     * @param name Timer name.
+     */
+    virtual void start(const std::string& name) = 0;
+
+    /**
+     * @brief Stop timing a named code section.
+     * @param name Timer name.
+     */
+    virtual void stop(const std::string& name) = 0;
+
+    /**
+     * @brief Output a profiling report for all timers.
+     */
+    virtual void report() = 0;
+
+    /**
+     * @brief Get the total accumulated time for a named section (in microseconds).
+     * @param name Timer name.
+     * @return Total time in microseconds.
+     */
+    [[nodiscard]] virtual uint64_t get_time_us(const std::string& name) const = 0;
+
+    /**
+     * @brief Get the number of times a named section was timed.
+     * @param name Timer name.
+     * @return Call count.
+     */
+    [[nodiscard]] virtual uint64_t get_call_count(const std::string& name) const = 0;
+};
+
+/**
+ * @brief Concrete timer implementation for profiling named code sections.
+ *
+ * Supports manual start/stop as well as RAII-based (scoped) timing.
+ * Reports all timers in alphabetical order.
+ */
+class Timer : public ITimer {
+public:
+    void start(const std::string& name) override
+    {
+        start_times_[name] = std::chrono::high_resolution_clock::now();
+    }
+
+    void stop(const std::string& name) override
+    {
+        auto end_time = std::chrono::high_resolution_clock::now();
+        auto it = start_times_.find(name);
+        if (it != start_times_.end()) {
+            auto duration =
+                std::chrono::duration_cast<std::chrono::microseconds>(end_time - it->second)
+                    .count();
+            accumulated_times_[name] += duration;
+            call_counts_[name]++;
+            start_times_.erase(it);
+        }
+    }
+
+    /**
+     * @brief Output a profiling report for all timers in alphabetical order.
+     *
+     * After reporting, all accumulated data is cleared.
+     */
+    void report() override
+    {
+        // Collect and sort keys in alphabetical order
+        std::vector<std::string> names;
+        names.reserve(accumulated_times_.size());
+        for (const auto& [name, _] : accumulated_times_) {
+            names.push_back(name);
+        }
+        std::ranges::sort(names);
+
+        log::info("---- Profiling Report ----");
+        for (const auto& name : names) {
+            uint64_t total_time = accumulated_times_[name];
+            uint64_t count = call_counts_[name];
+            double avg_time = static_cast<double>(total_time) / static_cast<double>(count);
+            log::info(
+                "[{}]: total={}us, calls={}, avg={:.2f}us", name, total_time, count, avg_time);
+        }
+        log::info("--------------------------");
+
+        start_times_.clear();
+        accumulated_times_.clear();
+        call_counts_.clear();
+    }
+
+    [[nodiscard]] uint64_t get_time_us(const std::string& name) const override
+    {
+        auto it = accumulated_times_.find(name);
+        if (it != accumulated_times_.end()) {
+            return it->second;
+        }
+        return 0;
+    }
+
+    [[nodiscard]] uint64_t get_call_count(const std::string& name) const override
+    {
+        auto it = call_counts_.find(name);
+        if (it != call_counts_.end()) {
+            return it->second;
+        }
+        return 0;
+    }
+
+private:
+    std::unordered_map<std::string, std::chrono::high_resolution_clock::time_point> start_times_;
+    std::unordered_map<std::string, uint64_t> accumulated_times_;
+    std::unordered_map<std::string, uint64_t> call_counts_;
+};
+
+/**
+ * @brief Null timer implementation (no-op).
+ *
+ * Used when profiling is disabled.
+ */
+class NullTimer : public ITimer {
+public:
+    void start(const std::string& /*name*/) override {}
+    void stop(const std::string& /*name*/) override {}
+    void report() override {}
+    [[nodiscard]] uint64_t get_time_us(const std::string& /*name*/) const override { return 0; }
+    [[nodiscard]] uint64_t get_call_count(const std::string& /*name*/) const override { return 0; }
+};
+
+/**
+ * @brief Abstract interface for a scoped timer (RAII).
+ */
+class IScopedTimer {
+public:
+    IScopedTimer() = default;
+    IScopedTimer(const IScopedTimer&) = delete;
+    IScopedTimer& operator=(const IScopedTimer&) = delete;
+    IScopedTimer(IScopedTimer&&) = delete;
+    IScopedTimer& operator=(IScopedTimer&&) = delete;
+    virtual ~IScopedTimer() = default;
+};
+
+/**
+ * @brief RAII-based scoped timer.
+ *
+ * Starts timing on construction and stops on destruction.
+ */
+class ScopedTimer : public IScopedTimer {
+public:
+    ScopedTimer(ITimer& timer, std::string name) : timer_(timer), name_(std::move(name))
+    {
+        timer_.start(name_);
+    }
+    ~ScopedTimer() override { timer_.stop(name_); }
+
+    ScopedTimer(const ScopedTimer&) = delete;
+    ScopedTimer& operator=(const ScopedTimer&) = delete;
+    ScopedTimer(ScopedTimer&&) = delete;
+    ScopedTimer& operator=(ScopedTimer&&) = delete;
+
+private:
+    ITimer& timer_;
+    std::string name_;
+};
+
+/**
+ * @brief Null scoped timer (no-op).
+ *
+ * Used when profiling is disabled.
+ */
+class NullScopedTimer : public IScopedTimer {
+public:
+    NullScopedTimer(ITimer& /*timer*/, const std::string& /*name*/) {}
+};
+
+} // namespace boyboy::profiling

--- a/src/boyboy/cart/mbc.cpp
+++ b/src/boyboy/cart/mbc.cpp
@@ -102,14 +102,14 @@ void Mbc::write(uint16_t addr, uint8_t value)
         // enable only on 0x0A, disable otherwise
         // discard upper 4 bits
         ram_enable_ = (value & 0x0F) == 0x0A;
-        log::debug("RAM enable set to {}", ram_enable_);
+        log::trace("RAM enable set to {}", ram_enable_);
     }
     else if (addr >= ROMBankNumberStart && addr <= ROMBankNumberEnd) {
         // Mask value to max number of banks or 5-bits max
         // e.g. 16 banks (0x10) masked to 4 bits (0x0F)
         value &= std::min((rom_bank_cnt_ - 1), 0x1F);
         rom_bank_select_ = value == 0 ? 1 : value; // if 0 always set to 1
-        log::debug("ROM bank selected: {}", rom_bank_select_);
+        log::trace("ROM bank selected: {}", rom_bank_select_);
     }
     else if (addr >= RAMBankNumberStart && addr <= RAMBankNumberEnd) {
         // 2 bit register
@@ -127,7 +127,7 @@ void Mbc::write(uint16_t addr, uint8_t value)
                 }
             }
 
-            log::debug("ROM/RAM banking mode 0: ROM bank selected: {}, RAM bank selected: {}",
+            log::trace("ROM/RAM banking mode 0: ROM bank selected: {}, RAM bank selected: {}",
                        rom_bank_select_,
                        ram_bank_select_);
         }
@@ -141,7 +141,7 @@ void Mbc::write(uint16_t addr, uint8_t value)
                 ram_bank_select_ %= ram_bank_cnt_;
             }
 
-            log::debug("ROM/RAM banking mode 1: ROM bank selected: {}, RAM bank selected: {}",
+            log::trace("ROM/RAM banking mode 1: ROM bank selected: {}, RAM bank selected: {}",
                        rom_bank_select_,
                        ram_bank_select_);
         }
@@ -149,7 +149,7 @@ void Mbc::write(uint16_t addr, uint8_t value)
     else if (addr >= BankingModeSelectStart && addr <= BankingModeSelectEnd) {
         // 1 bit register
         banking_mode_ = value & 0x01;
-        log::debug("Banking mode set to {}", banking_mode_);
+        log::trace("Banking mode set to {}", banking_mode_);
     }
     else if (addr >= mmu::ERAMStart && addr <= mmu::ERAMEnd && ram_bank_cnt_ > 0) {
         // write to RAM bank if any

--- a/src/boyboy/cpu/cpu.cpp
+++ b/src/boyboy/cpu/cpu.cpp
@@ -12,6 +12,7 @@
 #include "boyboy/cpu/instructions.h"
 #include "boyboy/cpu/instructions_table.h"
 #include "boyboy/log/logging.h"
+#include "boyboy/profiling/profiler_utils.h"
 
 namespace boyboy::cpu {
 
@@ -119,6 +120,8 @@ void Cpu::set_register(Reg16Name reg, uint16_t value)
 
 uint8_t Cpu::step()
 {
+    BB_PROFILE_SCOPE(profiling::FrameTimer::Cpu);
+
     interrupt_handler_.service();
 
     if (halted_) {

--- a/src/boyboy/cpu/cpu.cpp
+++ b/src/boyboy/cpu/cpu.cpp
@@ -157,7 +157,10 @@ uint8_t Cpu::step()
 
 uint8_t Cpu::fetch()
 {
-    return read_byte(registers_.pc++);
+    BB_PROFILE_START(profiling::HotSection::CpuFetch);
+    uint8_t result = read_byte(registers_.pc++);
+    BB_PROFILE_STOP(profiling::HotSection::CpuFetch);
+    return result;
 }
 
 [[nodiscard]] uint8_t Cpu::peek() const
@@ -167,9 +170,11 @@ uint8_t Cpu::fetch()
 
 uint8_t Cpu::execute(uint8_t opcode, InstructionType instr_type)
 {
+    BB_PROFILE_START(profiling::HotSection::CpuExecute);
     const auto& instr = InstructionTable::get_instruction(instr_type, opcode);
     (this->*instr.execute)();
     cycles_ += instr.cycles;
+    BB_PROFILE_STOP(profiling::HotSection::CpuExecute);
     return instr.cycles;
 }
 

--- a/src/boyboy/display.cpp
+++ b/src/boyboy/display.cpp
@@ -6,9 +6,9 @@
  */
 
 // clang-format off
- #define GLAD_GL_IMPLEMENTATION
- #include <glad/gl.h>
- #include <SDL2/SDL.h>
+#define GLAD_GL_IMPLEMENTATION
+#include <glad/gl.h>
+#include <SDL2/SDL.h>
 // clang-format on
 
 #include "boyboy/display.h"
@@ -19,6 +19,7 @@
 #include "boyboy/io/buttons.h"
 #include "boyboy/log/logging.h"
 #include "boyboy/ppu/ppu.h"
+#include "boyboy/profiling/profiler_utils.h"
 
 namespace boyboy::display {
 
@@ -151,6 +152,8 @@ void Display::handle_key_event(const SDL_Event& event, bool pressed)
 
 void Display::render_frame(const ppu::FrameBuffer& framebuffer)
 {
+    BB_PROFILE_SCOPE(profiling::FrameTimer::Render);
+
     glTexSubImage2D(
         GL_TEXTURE_2D, 0, 0, 0, width_, height_, GL_RGBA, GL_UNSIGNED_BYTE, framebuffer.data());
 

--- a/src/boyboy/emulator.cpp
+++ b/src/boyboy/emulator.cpp
@@ -7,8 +7,12 @@
 
 #include "boyboy/emulator.h"
 
+#include <chrono>
+#include <thread>
+
 #include "boyboy/cart/cartridge_loader.h"
 #include "boyboy/log/logging.h"
+#include "boyboy/ppu/ppu.h"
 #include "boyboy/profiling/profiler_utils.h"
 
 namespace boyboy::emulator {
@@ -21,29 +25,13 @@ void Emulator::load(const std::string& path)
     mmu_->map_rom(cartridge_);
 }
 
-void Emulator::step()
+void Emulator::start()
 {
-    auto cycles = cpu_.step();
-    mmu_->tick_dma(cycles);
-    io_.tick(cycles);
-
-    // Update statistics before frame
-    instruction_count_++;
-    cycle_count_ += cycles;
-
-    if (ppu_.frame_ready()) {
-        display_.render_frame(ppu_.framebuffer());
-        ppu_.consume_frame();
-
-        // Update and log frame statistics
-        BB_PROFILE_FRAME(instruction_count_, cycle_count_);
-        instruction_count_ = 0;
-        cycle_count_ = 0;
+    if (started_) {
+        log::warn("Emulator already started");
+        return;
     }
-}
 
-void Emulator::run()
-{
     log::info("Starting emulator...");
 
     // Hook system callbacks
@@ -58,19 +46,56 @@ void Emulator::run()
     // ROM does it so we will enable it until we implement the boot ROM (if we ever do)
     ppu_.enable_lcd(true);
 
-    // TODO: running uncapped for now, add frame limiting when we optimize performance
-    running_ = true;
-    while (running_) {
-        step();
-        display_.poll_events(running_);
+    started_ = true;
+}
+
+void Emulator::stop()
+{
+    if (!started_) {
+        log::warn("Emulator not started");
+        return;
     }
+
+    log::info("Stopping emulator...");
 
     BB_PROFILE_REPORT();
     BB_FRAME_PROFILE_REPORT();
 
-    log::info("Stopping emulator...");
-
     display_.shutdown();
+    started_ = false;
+}
+
+void Emulator::run()
+{
+    start();
+
+    using clock = std::chrono::steady_clock;
+    auto next_frame_time = clock::now();
+    constexpr auto FrameDuration = std::chrono::duration_cast<clock::duration>(
+        std::chrono::duration<double>(ppu::FrameDuration));
+
+    // TODO: allow configurable frame rate for high refresh rate monitors and "turbo" mode.
+    // For now we run at the native frame rate (59.73Hz)
+    running_ = true;
+    while (running_) {
+        display_.poll_events(running_);
+        emulate_frame();
+        render_frame();
+
+        // Frame limiting (if needed) at 59.73Hz
+        if (frame_rate_limited_) {
+            next_frame_time += FrameDuration;
+            auto now = clock::now();
+            if (now < next_frame_time) {
+                std::this_thread::sleep_until(next_frame_time);
+            }
+            else {
+                next_frame_time = now;
+            }
+        }
+    }
+
+    stop();
 }
 
 void Emulator::reset()
@@ -89,6 +114,37 @@ void Emulator::on_button_event(io::Button button, bool pressed)
     else {
         joypad_.release(button);
     }
+}
+
+void Emulator::emulate_frame()
+{
+    while (!ppu_.frame_ready()) {
+        auto cycles = cpu_.step();
+        instruction_count_++;
+        cycle_count_ += cycles;
+
+        mmu_->tick_dma(cycles);
+        io_.tick(cycles);
+    }
+
+    // Check if there is any drift in the cycle count
+    constexpr int CycleDriftTolerance = 8;
+    int64_t cycle_diff =
+        static_cast<int64_t>(cycle_count_) - static_cast<int64_t>(ppu::CyclesPerFrame);
+    if (std::abs(cycle_diff) > CycleDriftTolerance) {
+        log::warn("Frame cycle count drift detected: {} cycles", cycle_diff);
+    }
+}
+
+void Emulator::render_frame()
+{
+    display_.render_frame(ppu_.framebuffer());
+    ppu_.consume_frame();
+
+    // Update and log frame statistics
+    BB_PROFILE_FRAME(instruction_count_, cycle_count_);
+    instruction_count_ = 0;
+    cycle_count_ = 0;
 }
 
 } // namespace boyboy::emulator

--- a/src/boyboy/emulator.cpp
+++ b/src/boyboy/emulator.cpp
@@ -59,6 +59,7 @@ void Emulator::stop()
     log::info("Stopping emulator...");
 
     BB_PROFILE_REPORT();
+    BB_HOT_PROFILE_REPORT();
     BB_FRAME_PROFILE_REPORT();
 
     display_.shutdown();

--- a/src/boyboy/mmu/mmu.cpp
+++ b/src/boyboy/mmu/mmu.cpp
@@ -462,13 +462,14 @@ void Mmu::init_memory_map()
 [[nodiscard]] size_t Mmu::find_region_index(uint16_t addr) const
 {
     for (size_t i = 0; i < memory_map_.size(); i++) {
-        auto region = memory_map_.at(i);
+        const auto& region = memory_map_.at(i);
         if (addr >= region.start && addr <= region.end) {
             return i;
         }
     }
 #ifndef NDEBUG
-    throw std::out_of_range(std::format("Invalid memory access at {}", utils::PrettyHex(addr).to_string()));
+    throw std::out_of_range(
+        std::format("Invalid memory access at {}", utils::PrettyHex(addr).to_string()));
 #else
     return size_t(-1);
 #endif

--- a/src/boyboy/ppu/ppu.cpp
+++ b/src/boyboy/ppu/ppu.cpp
@@ -16,6 +16,7 @@
 #include "boyboy/log/logging.h"
 #include "boyboy/mmu/constants.h"
 #include "boyboy/ppu/registers.h"
+#include "boyboy/profiling/profiler_utils.h"
 
 namespace boyboy::ppu {
 
@@ -23,6 +24,8 @@ using io::IoReg;
 
 void Ppu::tick(uint16_t cycles)
 {
+    BB_PROFILE_SCOPE(profiling::FrameTimer::Ppu);
+
     if (lcd_off()) {
         return;
     }


### PR DESCRIPTION
## Summary

Performance optimizations of the emulator, going from ~30-60FPS up to ~1700FPS (e.g. Tetris).  
Implementation of a profiling module to measure code execution and frame times.

## Added

- Profiling module to measure execution and frame times: `Timer`, `ScopedTimer`, `Profiler`, `FrameProfiler`
- Hot code sections profiling module `HotProfiler` to measure critical and high-frequency code (MMU read/write, CPU step/exec, etc.)
- Profiling API with optional helper macros: `profiler_utils.h`

## Changed

- Refactored `Emulator` and more specifically the emulation loop
  - Frame-based emulation loop
  - Moved `Display::poll_events` to start of each frame instead of calling every step
  - Replaced FPS/IPS/CPS counter in `emulator.cpp` for `FrameProfiler`
- Replace `Mmu` loop-based region finding for O(1) lookup table and other optimizations