### PR TITLE
CI runtime improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build --no-install-recommends cmake libsdl2-dev libopengl-dev
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: ninja-build cmake libsdl2-dev libopengl-dev
+          version: 1.0
 
       - name: Configure
         run: cmake --preset release-no-tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,17 +10,25 @@ on:
       - main
       - "release/*"
     types: [opened, reopened, synchronize, review_requested, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      preset:
+        description: "CMake preset to use"
+        required: false
+        default: "release"
 
 jobs:
   build-and-test:
-    name: Build & Test (${{ matrix.preset }})
-    runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    name: Build and Test
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         preset: [release]
+    env:
+      PRESET: ${{ github.event.inputs.preset || matrix.preset }}
 
     steps:
       - name: Workflow info
@@ -29,9 +37,11 @@ jobs:
           echo "Commit SHA: $GITHUB_SHA"
           echo "Actor: $GITHUB_ACTOR"
           echo "Event name: $GITHUB_EVENT_NAME"
+          echo "Event action: $GITHUB_EVENT_ACTION"
+          echo "Using preset: $PRESET"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -42,9 +52,9 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.os }}-${{ matrix.preset }}
+          key: ${{ matrix.os }}-${{ env.preset }}
 
       - name: Run CMake workflow
         uses: lukka/run-cmake@v10
         with:
-          workflowPreset: ${{ matrix.preset }}
+          workflowPreset: ${{ env.preset }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,6 @@ jobs:
           echo "Commit SHA: $GITHUB_SHA"
           echo "Actor: $GITHUB_ACTOR"
           echo "Event name: $GITHUB_EVENT_NAME"
-          echo "Event action: $GITHUB_EVENT_ACTION"
           echo "Using preset: $PRESET"
 
       - name: Checkout repository
@@ -52,9 +51,9 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.os }}-${{ env.preset }}
+          key: ${{ matrix.os }}-${{ env.PRESET }}
 
       - name: Run CMake workflow
         uses: lukka/run-cmake@v10
         with:
-          workflowPreset: ${{ env.preset }}
+          workflowPreset: ${{ env.PRESET }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,15 +45,22 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: ninja-build cmake libsdl2-dev libopengl-dev
+          packages: ninja-build cmake ccache libsdl2-dev libopengl-dev
           version: 1.0
 
-      - name: Setup ccache
+      - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.os }}-${{ env.PRESET }}
 
-      - name: Run CMake workflow
-        uses: lukka/run-cmake@v10
-        with:
-          workflowPreset: ${{ env.PRESET }}
+      - name: Configure CMake with Ccache
+        run: cmake --preset ${{ env.PRESET }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+
+      - name: Build project
+        run: cmake --build --preset ${{ env.PRESET }}
+
+      - name: Run tests
+        run: ctest --preset ${{ env.PRESET }}
+
+      - name: Show Ccache stats
+        run: ccache --show-stats

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies (Ubuntu)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ninja-build cmake libsdl2-dev libopengl-dev
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: ninja-build cmake libsdl2-dev libopengl-dev
+          version: 1.0
 
       - name: Cache CMake
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,21 +39,12 @@ jobs:
           packages: ninja-build cmake libsdl2-dev libopengl-dev
           version: 1.0
 
-      - name: Cache CMake
-        uses: actions/cache@v4
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: |
-            ~/.cache/CMake
-            build/
-          key: ${{ runner.os }}-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.preset }}-
+          key: ${{ matrix.os }}-${{ matrix.preset }}
 
-      - name: Configure CMake
-        run: cmake --preset ${{ matrix.preset }}
-
-      - name: Build project
-        run: cmake --build --preset ${{ matrix.preset }}
-
-      - name: Run tests
-        run: ctest --preset ${{ matrix.preset }}
+      - name: Run CMake workflow
+        uses: lukka/run-cmake@v10
+        with:
+          workflowPreset: ${{ matrix.preset }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,3 @@ jobs:
 
       - name: Run tests
         run: ctest --preset ${{ env.PRESET }}
-
-      - name: Show Ccache stats
-        run: ccache --show-stats


### PR DESCRIPTION
Improve execution time of Tests workflow after adding cache for APT packages and CMake build with Ccache.  

**On cache hits** the following runtime reductions have been accomplished:
- **APT** dependencies runtime reduced from ~2-3min to ~4-8s
- **CMake** build runtime reduced from ~1.5min to ~8s
- **Total** runtime reduced from ~4-5m to ~40s