### PR TITLE
Integrate CLI11 for command line interface

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,10 @@
             "request": "launch",
             "program": "${workspaceFolder}/bin/debug/${workspaceFolderBasename}",
             "args": [
-                "${input:romPath}"
+                "run",
+                "${input:romPath}",
+                "--config",
+                "${input:configPath}"
             ],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
@@ -57,6 +60,12 @@
             "type": "promptString",
             "description": "Enter ROM path",
             "default": "roms/dummy.gb"
+        },
+        {
+            "id": "configPath",
+            "type": "promptString",
+            "description": "Enter config path (leave empty for default)",
+            "default": ""
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,25 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   - `IConfigLoader` interface and `TomlConfigLoader` implementation.
   - `ConfigValidator` for config validation and normalization.
   - High-level API for loading and saving config files (`load_config`, `save_config`).
+- **Command execution system**.
+  - `App` executor class, `ICommand` interface and `CommandContext` for information passing, `CommandRegistry` for command registration.
+  - Concrete commands: `RunCommand` for emulator running, `InfoCommand` for ROM information, `ConfigCommand` for viewing and editing configuration.
+- **Command-Line Interface** with CLI11.
+  - CLI application `CLIApp`, abstract adapter interface `ICLIAdapter`, and concrete implementation `CLI11Adapter`.
+  - Run command with config, speed, scale, vsync and log level options.
+  - Info command to display ROM metadata information.
+  - Config with key-value get and set, and full configuration list and reset.
+  - Version and build information.
 - Log level configuration and conversion helpers.
 - Display accessors for scale and vsync.
 - Emulator configuration application method.
 - Frame limiting based on configured speed.
+- Version header generation with build metadata.
 - Unit tests for configuration logic.
 
 ### Changed
 
+- Main application entry point modified to use `CLIApp`
 - Emulator and Display now apply configuration at startup.
 - Logging system supports configurable log levels.
 - Reorganize codebase moving core components under `boyboy/core/` directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ add_executable(${BOYBOY_APP}
     src/boyboy/app/app.cpp
     src/boyboy/app/commands/run_command.cpp
     src/boyboy/app/commands/info_command.cpp
+    src/boyboy/app/commands/config_command.cpp
 )
 target_compile_options(${BOYBOY_APP} PRIVATE
     -Wall -Wextra -Wpedantic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ target_include_directories(${BOYBOY_LIB}
     PUBLIC
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/external
+    ${CMAKE_BINARY_DIR}/generated
     PRIVATE
     ${CMAKE_SOURCE_DIR}/src/boyboy
 )
@@ -170,6 +171,85 @@ if(ENABLE_SANITIZERS AND CMAKE_BUILD_TYPE MATCHES Debug)
     target_compile_options(${BOYBOY_LIB} PRIVATE -fsanitize=address,undefined)
     target_link_options(${BOYBOY_LIB} PRIVATE -fsanitize=address,undefined)
 endif()
+
+# ---- Build metadata ----
+# Build type (Debug/Release/etc.)
+if(CMAKE_BUILD_TYPE)
+    set(BOYBOY_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+else()
+    set(BOYBOY_BUILD_TYPE "Unknown")
+endif()
+
+# Compiler info
+set(BOYBOY_COMPILER_ID "${CMAKE_CXX_COMPILER_ID}")
+set(BOYBOY_COMPILER_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+
+# Try to get current Git commit hash
+find_package(Git QUIET)
+if(Git_FOUND)
+    # Short commit hash
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE BOYBOY_GIT_COMMIT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Detect dirty working tree
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} diff --quiet
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        RESULT_VARIABLE GIT_DIFF_RESULT
+    )
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} diff --cached --quiet
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        RESULT_VARIABLE GIT_DIFF_CACHED_RESULT
+    )
+
+    if(NOT GIT_DIFF_RESULT EQUAL 0 OR NOT GIT_DIFF_CACHED_RESULT EQUAL 0)
+        set(BOYBOY_GIT_COMMIT "${BOYBOY_GIT_COMMIT}-dirty")
+    endif()
+
+    # Current branch
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE BOYBOY_GIT_BRANCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    # Closest tag (if any)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE BOYBOY_GIT_TAG
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    set(BOYBOY_GIT_COMMIT "unknown")
+    set(BOYBOY_GIT_BRANCH "unknown")
+    set(BOYBOY_GIT_TAG "unknown")
+endif()
+
+# System info
+set(BOYBOY_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}")
+set(BOYBOY_SYSTEM_PROCESSOR "${CMAKE_SYSTEM_PROCESSOR}")
+
+# CMake info
+set(BOYBOY_CMAKE_VERSION "${CMAKE_VERSION}")
+
+# Build timestamp
+string(TIMESTAMP BOYBOY_BUILD_TIMESTAMP "%Y-%m-%d %H:%M:%S")
+
+# Configure version header
+configure_file(
+    ${CMAKE_SOURCE_DIR}/include/boyboy/version.h.in
+    ${CMAKE_BINARY_DIR}/generated/boyboy/version.h
+    @ONLY
+)
 
 # --- Tests ---
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,14 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(tomlplusplus)
 
+# --- Fetch CLI11 ---
+FetchContent_Declare(
+    cli11_proj
+    GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+    GIT_TAG v2.5.0
+)
+FetchContent_MakeAvailable(cli11_proj)
+
 # --- System dependencies ---
 find_package(OpenGL REQUIRED)
 find_package(SDL2 REQUIRED)
@@ -138,7 +146,13 @@ set_target_properties(${BOYBOY_LIB} PROPERTIES
 )
 
 # --- Executable ---
-add_executable(${BOYBOY_APP} src/boyboy/main.cpp)
+add_executable(${BOYBOY_APP}
+    src/boyboy/main.cpp
+    src/boyboy/frontend/cli/cli_app.cpp
+    src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
+    src/boyboy/app/app.cpp
+    src/boyboy/app/commands/run_command.cpp
+)
 target_compile_options(${BOYBOY_APP} PRIVATE
     -Wall -Wextra -Wpedantic
 )
@@ -146,6 +160,7 @@ target_compile_options(${BOYBOY_APP} PRIVATE
 # --- Link BoyBoy lib
 target_link_libraries(${BOYBOY_APP} PRIVATE
     ${BOYBOY_LIB}
+    CLI11::CLI11
 )
 
 # ---- Sanitizer option ----

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ add_executable(${BOYBOY_APP}
     src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
     src/boyboy/app/app.cpp
     src/boyboy/app/commands/run_command.cpp
+    src/boyboy/app/commands/info_command.cpp
 )
 target_compile_options(${BOYBOY_APP} PRIVATE
     -Wall -Wextra -Wpedantic

--- a/include/boyboy/app/app.h
+++ b/include/boyboy/app/app.h
@@ -33,6 +33,9 @@ public:
     [[nodiscard]] const common::config::Config& get_config() const { return config_; }
     [[nodiscard]] common::config::Config& get_config() { return config_; }
 
+    // ROM information
+    [[nodiscard]] static std::string rom_info(std::string_view rom_path);
+
     // Version information
     [[nodiscard]] static std::string version();
     [[nodiscard]] static std::string build_info();

--- a/include/boyboy/app/app.h
+++ b/include/boyboy/app/app.h
@@ -1,0 +1,37 @@
+/**
+ * @file app.h
+ * @brief Main application class for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include "boyboy/common/config/config.h"
+#include "boyboy/core/emulator/emulator.h"
+
+namespace boyboy::common::config {
+struct Config;
+}
+
+namespace boyboy::core::emulator {
+class Emulator;
+}
+
+namespace boyboy::app {
+
+class App {
+public:
+    int run(std::string_view rom_path, std::string_view config_path = "");
+
+    void load_config(std::string_view config_path = "");
+    [[nodiscard]] const common::config::Config& get_config() const;
+
+private:
+    common::config::Config config_;
+    core::emulator::Emulator emulator_;
+};
+
+} // namespace boyboy::app

--- a/include/boyboy/app/app.h
+++ b/include/boyboy/app/app.h
@@ -25,11 +25,17 @@ namespace boyboy::app {
 
 class App {
 public:
+    // Main application operations
     int run(std::string_view rom_path);
 
+    // Configuration management
     common::config::Config& load_config(std::optional<std::string_view> config_path = std::nullopt);
     [[nodiscard]] const common::config::Config& get_config() const { return config_; }
     [[nodiscard]] common::config::Config& get_config() { return config_; }
+
+    // Version information
+    [[nodiscard]] static std::string version();
+    [[nodiscard]] static std::string build_info();
 
 private:
     common::config::Config config_ = common::config::Config::default_config();

--- a/include/boyboy/app/app.h
+++ b/include/boyboy/app/app.h
@@ -30,6 +30,14 @@ public:
 
     // Configuration management
     common::config::Config& load_config(std::optional<std::string_view> config_path = std::nullopt);
+    void save_config(
+        const common::config::Config& config,
+        std::optional<std::string_view> config_path = std::nullopt
+    );
+    void save_config(std::optional<std::string_view> config_path = std::nullopt)
+    {
+        save_config(config_, config_path);
+    }
     [[nodiscard]] const common::config::Config& get_config() const { return config_; }
     [[nodiscard]] common::config::Config& get_config() { return config_; }
 

--- a/include/boyboy/app/app.h
+++ b/include/boyboy/app/app.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 
 #include "boyboy/common/config/config.h"
@@ -24,13 +25,14 @@ namespace boyboy::app {
 
 class App {
 public:
-    int run(std::string_view rom_path, std::string_view config_path = "");
+    int run(std::string_view rom_path);
 
-    void load_config(std::string_view config_path = "");
-    [[nodiscard]] const common::config::Config& get_config() const;
+    common::config::Config& load_config(std::optional<std::string_view> config_path = std::nullopt);
+    [[nodiscard]] const common::config::Config& get_config() const { return config_; }
+    [[nodiscard]] common::config::Config& get_config() { return config_; }
 
 private:
-    common::config::Config config_;
+    common::config::Config config_ = common::config::Config::default_config();
     core::emulator::Emulator emulator_;
 };
 

--- a/include/boyboy/app/commands/command.h
+++ b/include/boyboy/app/commands/command.h
@@ -20,9 +20,6 @@ namespace boyboy::app::commands {
 struct CommandContext {
     std::string rom_path;
     std::optional<std::string> config_path;
-    std::optional<int> scale;
-    std::optional<int> speed;
-    std::optional<bool> vsync;
     std::optional<std::string> log_level;
 };
 

--- a/include/boyboy/app/commands/command.h
+++ b/include/boyboy/app/commands/command.h
@@ -1,0 +1,37 @@
+/**
+ * @file command.h
+ * @brief Command interface for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "boyboy/app/app.h"
+
+namespace boyboy::app::commands {
+
+struct CommandContext {
+    App app;
+    std::string rom_path;
+    std::string config_path;
+};
+
+class ICommand {
+public:
+    ICommand() = default;
+    virtual ~ICommand() = default;
+    ICommand(ICommand&) = delete;
+    ICommand(ICommand&&) = delete;
+    ICommand& operator=(ICommand&) = delete;
+    ICommand& operator=(ICommand&&) = delete;
+
+    [[nodiscard]] virtual std::string_view name() const = 0;
+    [[nodiscard]] virtual std::string_view description() const = 0;
+    virtual int execute(CommandContext& context) = 0;
+};
+
+} // namespace boyboy::app::commands

--- a/include/boyboy/app/commands/command.h
+++ b/include/boyboy/app/commands/command.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -18,7 +19,11 @@ namespace boyboy::app::commands {
 
 struct CommandContext {
     std::string rom_path;
-    std::string config_path;
+    std::optional<std::string> config_path;
+    std::optional<int> scale;
+    std::optional<int> speed;
+    std::optional<bool> vsync;
+    std::optional<std::string> log_level;
 };
 
 class ICommand {

--- a/include/boyboy/app/commands/command.h
+++ b/include/boyboy/app/commands/command.h
@@ -10,12 +10,13 @@
 #include <string>
 #include <string_view>
 
-#include "boyboy/app/app.h"
+namespace boyboy::app {
+class App;
+}
 
 namespace boyboy::app::commands {
 
 struct CommandContext {
-    App app;
     std::string rom_path;
     std::string config_path;
 };
@@ -31,7 +32,7 @@ public:
 
     [[nodiscard]] virtual std::string_view name() const = 0;
     [[nodiscard]] virtual std::string_view description() const = 0;
-    virtual int execute(CommandContext& context) = 0;
+    virtual int execute(App& app, const CommandContext& context) = 0;
 };
 
 } // namespace boyboy::app::commands

--- a/include/boyboy/app/commands/command_registry.h
+++ b/include/boyboy/app/commands/command_registry.h
@@ -1,0 +1,72 @@
+/**
+ * @file command_registry.h
+ * @brief Command registry for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "boyboy/app/commands/command.h"
+
+namespace boyboy::app {
+class App;
+}
+
+namespace boyboy::app::commands {
+
+// Macro to register a command class with the registry
+#define REGISTER_COMMAND(TYPE)                                                                     \
+    static const bool TYPE##_registered = [] {                                                     \
+        boyboy::app::commands::CommandRegistry::instance().register_factory(#TYPE, [] {            \
+            return std::make_unique<TYPE>();                                                       \
+        });                                                                                        \
+        return true;                                                                               \
+    }()
+
+// Concept to ensure the registrar has the required register_command method
+template <typename T>
+concept CommandRegistrar = requires(T& registrar, ICommand& cmd) {
+    registrar.register_command(cmd);
+};
+
+class CommandRegistry {
+public:
+    using Factory = std::function<std::unique_ptr<ICommand>()>;
+
+    static CommandRegistry& instance()
+    {
+        static CommandRegistry reg;
+        return reg;
+    }
+
+    void register_factory(std::string_view name, Factory factory)
+    {
+        factories_[std::string(name)] = std::move(factory);
+    }
+
+    template <typename CommandRegister>
+        requires CommandRegistrar<CommandRegister>
+    void register_all(CommandRegister& reg)
+    {
+        for (auto& [name, factory] : factories_) {
+            auto cmd = factory();
+            reg.register_command(*cmd);
+            commands_.push_back(std::move(cmd));
+        }
+    }
+
+private:
+    std::unordered_map<std::string, Factory> factories_;
+    std::vector<std::unique_ptr<ICommand>> commands_;
+};
+
+} // namespace boyboy::app::commands

--- a/include/boyboy/app/commands/config_command.h
+++ b/include/boyboy/app/commands/config_command.h
@@ -28,9 +28,9 @@ public:
     [[nodiscard]] SubCommand get_subcommand() const { return subcommand_; }
     void set_subcommand(SubCommand cmd) { subcommand_ = cmd; }
     [[nodiscard]] std::optional<std::string> get_key() const { return key_; }
-    void set_key(std::string_view key) { key_ = std::string(key); }
+    void set_key(const std::optional<std::string>& key) { key_ = key; }
     [[nodiscard]] std::optional<std::string> get_value() const { return value_; }
-    void set_value(std::string_view value) { value_ = std::string(value); }
+    void set_value(const std::optional<std::string>& value) { value_ = value; }
 
 private:
     static constexpr std::string_view Name = "config";

--- a/include/boyboy/app/commands/config_command.h
+++ b/include/boyboy/app/commands/config_command.h
@@ -1,0 +1,49 @@
+/**
+ * @file config_command.h
+ * @brief Config command for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "boyboy/app/commands/command.h"
+
+namespace boyboy::app::commands {
+
+class ConfigCommand : public ICommand {
+public:
+    enum class SubCommand : uint8_t { Get, Set, List, Reset, None };
+
+    [[nodiscard]] std::string_view name() const override { return Name; }
+    [[nodiscard]] std::string_view description() const override { return Description; }
+    int execute(App& app, const CommandContext& context) override;
+
+    // Accessors
+    [[nodiscard]] SubCommand get_subcommand() const { return subcommand_; }
+    void set_subcommand(SubCommand cmd) { subcommand_ = cmd; }
+    [[nodiscard]] std::optional<std::string> get_key() const { return key_; }
+    void set_key(std::string_view key) { key_ = std::string(key); }
+    [[nodiscard]] std::optional<std::string> get_value() const { return value_; }
+    void set_value(std::string_view value) { value_ = std::string(value); }
+
+private:
+    static constexpr std::string_view Name = "config";
+    static constexpr std::string_view Description = "Manage emulator configuration";
+
+    SubCommand subcommand_{SubCommand::None};
+    std::optional<std::string> key_;
+    std::optional<std::string> value_;
+
+    int execute_get(App& app, const CommandContext& context);
+    int execute_set(App& app, const CommandContext& context);
+    int execute_list(App& app, const CommandContext& context);
+    int execute_reset(App& app, const CommandContext& context);
+};
+
+} // namespace boyboy::app::commands

--- a/include/boyboy/app/commands/info_command.h
+++ b/include/boyboy/app/commands/info_command.h
@@ -1,0 +1,25 @@
+/**
+ * @file info_command.h
+ * @brief Info command for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include "boyboy/app/commands/command.h"
+
+namespace boyboy::app::commands {
+
+class InfoCommand : public ICommand {
+public:
+    [[nodiscard]] std::string_view name() const override { return Name; }
+    [[nodiscard]] std::string_view description() const override { return Description; }
+    int execute(App& app, const CommandContext& context) override;
+
+private:
+    static constexpr std::string_view Name = "info";
+    static constexpr std::string_view Description = "Display ROM metadata information";
+};
+
+} // namespace boyboy::app::commands

--- a/include/boyboy/app/commands/run_command.h
+++ b/include/boyboy/app/commands/run_command.h
@@ -1,0 +1,31 @@
+/**
+ * @file run_command.h
+ * @brief Run command for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include "boyboy/app/app.h"
+#include "boyboy/app/commands/command.h"
+
+namespace boyboy::app::commands {
+
+class RunCommand : public ICommand {
+public:
+    [[nodiscard]] std::string_view name() const override { return Name; }
+    [[nodiscard]] std::string_view description() const override { return Description; }
+    int execute(CommandContext& context) override
+    {
+        return context.app.run(context.rom_path, context.config_path);
+    }
+
+private:
+    static constexpr std::string_view Name = "run";
+    static constexpr std::string_view Description = "Run the emulator with the specified ROM file";
+};
+
+} // namespace boyboy::app::commands

--- a/include/boyboy/app/commands/run_command.h
+++ b/include/boyboy/app/commands/run_command.h
@@ -18,9 +18,9 @@ class RunCommand : public ICommand {
 public:
     [[nodiscard]] std::string_view name() const override { return Name; }
     [[nodiscard]] std::string_view description() const override { return Description; }
-    int execute(CommandContext& context) override
+    int execute(App& app, const CommandContext& context) override
     {
-        return context.app.run(context.rom_path, context.config_path);
+        return app.run(context.rom_path, context.config_path);
     }
 
 private:

--- a/include/boyboy/app/commands/run_command.h
+++ b/include/boyboy/app/commands/run_command.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 
 #include "boyboy/app/app.h"
@@ -20,9 +21,21 @@ public:
     [[nodiscard]] std::string_view description() const override { return Description; }
     int execute(App& app, const CommandContext& context) override;
 
+    // Accessors
+    [[nodiscard]] std::optional<int> get_speed() const { return speed_; }
+    void set_speed(std::optional<int> speed) { speed_ = speed; }
+    [[nodiscard]] std::optional<int> get_scale() const { return scale_; }
+    void set_scale(std::optional<int> scale) { scale_ = scale; }
+    [[nodiscard]] std::optional<bool> get_vsync() const { return vsync_; }
+    void set_vsync(std::optional<bool> vsync) { vsync_ = vsync; }
+
 private:
     static constexpr std::string_view Name = "run";
     static constexpr std::string_view Description = "Run the emulator with the specified ROM file";
+
+    std::optional<int> scale_;
+    std::optional<int> speed_;
+    std::optional<bool> vsync_;
 };
 
 } // namespace boyboy::app::commands

--- a/include/boyboy/app/commands/run_command.h
+++ b/include/boyboy/app/commands/run_command.h
@@ -18,10 +18,7 @@ class RunCommand : public ICommand {
 public:
     [[nodiscard]] std::string_view name() const override { return Name; }
     [[nodiscard]] std::string_view description() const override { return Description; }
-    int execute(App& app, const CommandContext& context) override
-    {
-        return app.run(context.rom_path, context.config_path);
-    }
+    int execute(App& app, const CommandContext& context) override;
 
 private:
     static constexpr std::string_view Name = "run";

--- a/include/boyboy/common/config/config.h
+++ b/include/boyboy/common/config/config.h
@@ -7,12 +7,23 @@
 
 #pragma once
 
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include "boyboy/common/config/config_limits.h"
 
 namespace boyboy::common::config {
+
+template <typename T>
+concept ValidConfigType = std::same_as<T, int> || std::same_as<T, bool> ||
+                          std::same_as<T, std::string>;
 
 struct ConfigKeys {
     struct Emulator {
@@ -28,60 +39,172 @@ struct ConfigKeys {
         static constexpr std::string_view Section = "debug";
         static constexpr std::string_view LogLevel = "log_level";
     };
+
+    // Full keys for easy access
+    inline static const std::string EmulatorSpeed = std::string(Emulator::Section) + "." +
+                                                    std::string(Emulator::Speed);
+    inline static const std::string VideoScale = std::string(Video::Section) + "." +
+                                                 std::string(Video::Scale);
+    inline static const std::string VideoVSync = std::string(Video::Section) + "." +
+                                                 std::string(Video::VSync);
+    inline static const std::string DebugLogLevel = std::string(Debug::Section) + "." +
+                                                    std::string(Debug::LogLevel);
+};
+
+struct ConfigMeta {
+    enum class Type : uint8_t { Int, Bool, String, None };
+
+    [[nodiscard]] static ConfigMeta::Type get_type(std::string_view key)
+    {
+        auto it = ConfigMetadata.find(std::string(key));
+        return (it != ConfigMetadata.end()) ? it->second : Type::None;
+    }
+
+private:
+    inline static const std::unordered_map<std::string, ConfigMeta::Type> ConfigMetadata = {
+        {ConfigKeys::EmulatorSpeed, Type::Int},
+        {ConfigKeys::VideoScale, Type::Int},
+        {ConfigKeys::VideoVSync, Type::Bool},
+        {ConfigKeys::DebugLogLevel, Type::String},
+    };
 };
 
 struct Config {
 
     struct Emulator {
         int speed = ConfigLimits::Emulator::SpeedRange.default_value;
-        // std::string save_path = "saves/"; // directory for save files
-        // bool auto_save = true;            // auto-save on exit
-        // bool auto_load = true;            // auto-load on start
-        // int auto_save_interval = 300;     // auto-save interval in seconds, 0 = disabled
-        // bool skip_boot = false;           // skip boot ROM
-        // std::string boot_rom_path;        // path to custom boot ROM, empty = default
-    } emulator;
-
-    // struct Input {
-    //     struct Keymap {
-    //         // Game Boy buttons
-    //         std::string up = "up";
-    //         std::string down = "down";
-    //         std::string left = "left";
-    //         std::string right = "right";
-    //         std::string a = "z";
-    //         std::string b = "x";
-    //         std::string start = "enter";
-    //         std::string select = "backspace";
-
-    //         // Emulator controls
-    //         std::string pause = "space";
-    //         std::string reset = "r";
-    //         std::string fullscreen = "f11";
-    //         std::string screenshot = "f12";
-    //         std::string turbo = "lshift";
-    //         std::string increase_speed = "pageup";
-    //         std::string decrease_speed = "pagedown";
-    //         std::string quick_save = "f5";
-    //         std::string quick_load = "f8";
-    //     } keymap;
-    // } input;
+    } emulator; // NOLINT
 
     struct Video {
         int scale = ConfigLimits::Video::ScaleRange.default_value;
         bool vsync = true;
-        // bool fullscreen = false;
-        // int frame_limit = 60; // max FPS: 0 = uncapped
-
-    } video;
+    } video; // NOLINT
 
     struct Debug {
         std::string log_level = std::string(ConfigLimits::Debug::LogLevelOptions.default_value);
-        // bool profiling = false;         // enable performance profiling
-        // bool trace_cpu = false;         // enable CPU instruction tracing
-    } debug;
+    } debug; // NOLINT
 
     static Config default_config() { return Config{}; }
+
+    template <ValidConfigType T>
+    [[nodiscard]] T& get(std::string_view key)
+    {
+        std::string key_str(key);
+        auto it = config_map_.find(key_str);
+        if (it == config_map_.end()) {
+            throw std::invalid_argument("Invalid config key: " + key_str);
+        }
+
+        bool type_mismatch = true;
+        if constexpr (std::same_as<T, int>) {
+            type_mismatch = ConfigMeta::get_type(key) != ConfigMeta::Type::Int;
+        }
+        else if constexpr (std::same_as<T, bool>) {
+            type_mismatch = ConfigMeta::get_type(key) != ConfigMeta::Type::Bool;
+        }
+        else if constexpr (std::same_as<T, std::string>) {
+            type_mismatch = ConfigMeta::get_type(key) != ConfigMeta::Type::String;
+        }
+
+        if (type_mismatch) {
+            throw std::invalid_argument("Type mismatch for config key: " + key_str);
+        }
+
+        return it->second.get<T>(*this);
+    }
+
+    template <ValidConfigType T>
+    void set(std::string_view key, const T& value)
+    {
+        get<T>(key) = value;
+    }
+
+    void set_string(std::string_view key, std::string_view value)
+    {
+        auto type = ConfigMeta::get_type(key);
+        switch (type) {
+            case ConfigMeta::Type::Int:
+                set<int>(key, parse_int(value));
+                break;
+            case ConfigMeta::Type::Bool:
+                set<bool>(key, parse_bool(value));
+                break;
+            case ConfigMeta::Type::String:
+                set<std::string>(key, std::string(value));
+                break;
+            default:
+                throw std::invalid_argument("Invalid config key: " + std::string(key));
+        }
+    }
+
+    [[nodiscard]] std::string key_value_str(std::string_view key)
+    {
+        std::ostringstream oss;
+        oss << key << ": ";
+        auto type = ConfigMeta::get_type(key);
+        switch (type) {
+            case ConfigMeta::Type::Int:
+                oss << get<int>(key);
+                break;
+            case ConfigMeta::Type::Bool:
+                oss << get<bool>(key);
+                break;
+            case ConfigMeta::Type::String:
+                oss << get<std::string>(key);
+                break;
+            default:
+                oss << "Invalid key";
+                break;
+        }
+        return oss.str();
+    }
+
+private:
+    struct ConfigAccessor {
+        std::function<void*(Config&)> getter;
+        template <ValidConfigType T>
+        T& get(Config& config) const
+        {
+            return *static_cast<T*>(getter(config));
+        }
+    };
+
+    std::unordered_map<std::string, ConfigAccessor> config_map_{
+        {ConfigKeys::EmulatorSpeed, ConfigAccessor{[](Config& c) {
+             return &c.emulator.speed;
+         }}},
+        {ConfigKeys::VideoScale, ConfigAccessor{[](Config& c) {
+             return &c.video.scale;
+         }}},
+        {ConfigKeys::VideoVSync, ConfigAccessor{[](Config& c) {
+             return &c.video.vsync;
+         }}},
+        {ConfigKeys::DebugLogLevel, ConfigAccessor{[](Config& c) {
+             return &c.debug.log_level;
+         }}},
+    };
+
+    static bool parse_bool(std::string_view value)
+    {
+        if (value == "true" || value == "1") {
+            return true;
+        }
+        if (value == "false" || value == "0") {
+            return false;
+        }
+
+        throw std::invalid_argument("Invalid bool value: " + std::string(value));
+    }
+
+    static int parse_int(std::string_view value)
+    {
+        size_t pos = 0;
+        int int_val = std::stoi(std::string(value), &pos);
+        if (pos != value.size()) {
+            throw std::invalid_argument("Invalid integer value: " + std::string(value));
+        }
+        return int_val;
+    }
 };
 
 } // namespace boyboy::common::config

--- a/include/boyboy/common/config/config.h
+++ b/include/boyboy/common/config/config.h
@@ -49,6 +49,13 @@ struct ConfigKeys {
                                                  std::string(Video::VSync);
     inline static const std::string DebugLogLevel = std::string(Debug::Section) + "." +
                                                     std::string(Debug::LogLevel);
+
+    inline static const std::vector<std::string> KeyList = {
+        EmulatorSpeed,
+        VideoScale,
+        VideoVSync,
+        DebugLogLevel,
+    };
 };
 
 struct ConfigMeta {

--- a/include/boyboy/common/config/config_limits.h
+++ b/include/boyboy/common/config/config_limits.h
@@ -50,8 +50,8 @@ struct ConfigLimits {
     };
 
     struct Debug {
-        static constexpr std::array<std::string_view, 5> LogLevels = {
-            "trace", "debug", "info", "warning", "error"
+        static constexpr std::array<std::string_view, 7> LogLevels = {
+            "trace", "debug", "info", "warn", "error", "critical", "off"
         };
 
         static constexpr Options<std::string_view> LogLevelOptions = {

--- a/include/boyboy/common/config/config_utils.h
+++ b/include/boyboy/common/config/config_utils.h
@@ -23,6 +23,7 @@ load_config(const std::optional<std::filesystem::path>& path = std::nullopt, boo
 void save_config(
     const Config& config, const std::optional<std::filesystem::path>& path = std::nullopt
 );
+void validate_config(Config& config, bool normalize = true);
 
 std::filesystem::path default_config_path();
 

--- a/include/boyboy/common/config/config_validator.h
+++ b/include/boyboy/common/config/config_validator.h
@@ -24,6 +24,7 @@ struct ValidationResult {
 class ConfigValidator {
 public:
     static ValidationResult validate(Config& config, bool normalize = false);
+    static void check_result(const ValidationResult& result);
 
 private:
     template <typename Limit, typename Value>

--- a/include/boyboy/core/emulator/emulator.h
+++ b/include/boyboy/core/emulator/emulator.h
@@ -5,6 +5,8 @@
  * @license GPLv3 (see LICENSE file)
  */
 
+#pragma once
+
 #include <memory>
 #include <string>
 

--- a/include/boyboy/frontend/cli/adapters/cli11_adapter.h
+++ b/include/boyboy/frontend/cli/adapters/cli11_adapter.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <CLI/CLI.hpp>
+#include <optional>
 
 #include "boyboy/app/commands/command.h"
 #include "boyboy/frontend/cli/adapters/cli_adapter.h"
@@ -27,6 +28,16 @@ public:
     void register_command(app::commands::ICommand& command) override;
 
 private:
+    struct CLIOptions {
+        // Run
+        std::optional<int> scale;
+        std::optional<int> speed;
+        std::optional<bool> vsync;
+        // Config
+        std::optional<std::string> cfg_key;
+        std::optional<std::string> cfg_value;
+    } options_;
+
     CLI::App app_parser_;
     app::App& app_;
     app::commands::CommandContext& context_;

--- a/include/boyboy/frontend/cli/adapters/cli11_adapter.h
+++ b/include/boyboy/frontend/cli/adapters/cli11_adapter.h
@@ -28,6 +28,7 @@ private:
     int parse(std::span<std::string_view> args);
 
     void register_run(app::commands::ICommand& command);
+    void register_info(app::commands::ICommand& command);
 };
 
 } // namespace boyboy::frontend::cli

--- a/include/boyboy/frontend/cli/adapters/cli11_adapter.h
+++ b/include/boyboy/frontend/cli/adapters/cli11_adapter.h
@@ -15,16 +15,17 @@
 namespace boyboy::frontend::cli {
 class CLI11Adapter : public ICLIAdapter {
 public:
-    explicit CLI11Adapter(app::commands::CommandContext& context);
+    explicit CLI11Adapter(app::App& app, app::commands::CommandContext& context);
 
     int run(std::span<std::string_view> args) override;
     void register_command(app::commands::ICommand& command) override;
 
 private:
     CLI::App app_parser_;
+    app::App& app_;
     app::commands::CommandContext& context_;
 
-    void parse(std::span<std::string_view> args);
+    int parse(std::span<std::string_view> args);
 
     void register_run(app::commands::ICommand& command);
 };

--- a/include/boyboy/frontend/cli/adapters/cli11_adapter.h
+++ b/include/boyboy/frontend/cli/adapters/cli11_adapter.h
@@ -1,0 +1,32 @@
+/**
+ * @file cli11_adapter.h
+ * @brief CLI11 adapter for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <CLI/CLI.hpp>
+
+#include "boyboy/app/commands/command.h"
+#include "boyboy/frontend/cli/adapters/cli_adapter.h"
+
+namespace boyboy::frontend::cli {
+class CLI11Adapter : public ICLIAdapter {
+public:
+    explicit CLI11Adapter(app::commands::CommandContext& context);
+
+    int run(std::span<std::string_view> args) override;
+    void register_command(app::commands::ICommand& command) override;
+
+private:
+    CLI::App app_parser_;
+    app::commands::CommandContext& context_;
+
+    void parse(std::span<std::string_view> args);
+
+    void register_run(app::commands::ICommand& command);
+};
+
+} // namespace boyboy::frontend::cli

--- a/include/boyboy/frontend/cli/adapters/cli11_adapter.h
+++ b/include/boyboy/frontend/cli/adapters/cli11_adapter.h
@@ -12,6 +12,12 @@
 #include "boyboy/app/commands/command.h"
 #include "boyboy/frontend/cli/adapters/cli_adapter.h"
 
+namespace boyboy::app::commands {
+class RunCommand;
+class InfoCommand;
+class ConfigCommand;
+} // namespace boyboy::app::commands
+
 namespace boyboy::frontend::cli {
 class CLI11Adapter : public ICLIAdapter {
 public:
@@ -27,8 +33,9 @@ private:
 
     int parse(std::span<std::string_view> args);
 
-    void register_run(app::commands::ICommand& command);
-    void register_info(app::commands::ICommand& command);
+    void register_run(app::commands::RunCommand& command);
+    void register_info(app::commands::InfoCommand& command);
+    void register_config(app::commands::ConfigCommand& command);
 };
 
 } // namespace boyboy::frontend::cli

--- a/include/boyboy/frontend/cli/adapters/cli_adapter.h
+++ b/include/boyboy/frontend/cli/adapters/cli_adapter.h
@@ -1,0 +1,30 @@
+/**
+ * @file cli_adapter.h
+ * @brief CLI adapter interface for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <span>
+#include <string_view>
+
+#include "boyboy/app/commands/command.h"
+
+namespace boyboy::frontend::cli {
+
+class ICLIAdapter {
+public:
+    ICLIAdapter() = default;
+    virtual ~ICLIAdapter() = default;
+    ICLIAdapter(ICLIAdapter&) = delete;
+    ICLIAdapter(ICLIAdapter&&) = delete;
+    ICLIAdapter& operator=(ICLIAdapter&) = delete;
+    ICLIAdapter& operator=(ICLIAdapter&&) = delete;
+
+    virtual int run(std::span<std::string_view> args) = 0;
+    virtual void register_command(app::commands::ICommand& command) = 0;
+};
+
+} // namespace boyboy::frontend::cli

--- a/include/boyboy/frontend/cli/cli_app.h
+++ b/include/boyboy/frontend/cli/cli_app.h
@@ -1,0 +1,30 @@
+/**
+ * @file cli_app.h
+ * @brief Command line interface application for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <memory>
+#include <span>
+
+#include "boyboy/app/commands/command.h"
+#include "boyboy/frontend/cli/adapters/cli_adapter.h"
+
+namespace boyboy::frontend::cli {
+
+class CLIApp {
+public:
+    CLIApp();
+    int run(std::span<std::string_view> args);
+
+private:
+    app::commands::CommandContext context_;
+    std::unique_ptr<ICLIAdapter> cli_adapter_;
+
+    void setup_commands();
+};
+
+} // namespace boyboy::frontend::cli

--- a/include/boyboy/frontend/cli/cli_app.h
+++ b/include/boyboy/frontend/cli/cli_app.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <span>
 
+#include "boyboy/app/app.h"
 #include "boyboy/app/commands/command.h"
 #include "boyboy/frontend/cli/adapters/cli_adapter.h"
 
@@ -21,6 +22,7 @@ public:
     int run(std::span<std::string_view> args);
 
 private:
+    app::App app_;
     app::commands::CommandContext context_;
     std::unique_ptr<ICLIAdapter> cli_adapter_;
 

--- a/include/boyboy/version.h.in
+++ b/include/boyboy/version.h.in
@@ -1,0 +1,45 @@
+/**
+ * @file version.h
+ * @brief Version information for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <string_view>
+#include <tuple>
+
+namespace boyboy::version {
+
+// ---- Semantic version ----
+// clang-format off
+inline constexpr int VersionMajor = @PROJECT_VERSION_MAJOR@;
+inline constexpr int VersionMinor = @PROJECT_VERSION_MINOR@;
+inline constexpr int VersionPatch = @PROJECT_VERSION_PATCH@;
+// clang-format on
+
+inline constexpr const char* VersionStr = "@PROJECT_VERSION@";
+inline constexpr auto VersionTuple = std::make_tuple(VersionMajor, VersionMinor, VersionPatch);
+
+// ---- Build metadata ----
+inline constexpr std::string_view BuildType = "@BOYBOY_BUILD_TYPE@";
+inline constexpr std::string_view CompilerID = "@BOYBOY_COMPILER_ID@";
+inline constexpr std::string_view CompilerVersion = "@BOYBOY_COMPILER_VERSION@";
+
+inline constexpr std::string_view GitCommit = "@BOYBOY_GIT_COMMIT@";
+inline constexpr std::string_view GitBranch = "@BOYBOY_GIT_BRANCH@";
+inline constexpr std::string_view GitTag = "@BOYBOY_GIT_TAG@";
+
+inline constexpr std::string_view SystemName = "@BOYBOY_SYSTEM_NAME@";
+inline constexpr std::string_view SystemProcessor = "@BOYBOY_SYSTEM_PROCESSOR@";
+inline constexpr std::string_view CmakeVersion = "@BOYBOY_CMAKE_VERSION@";
+inline constexpr std::string_view BuildTimestamp = "@BOYBOY_BUILD_TIMESTAMP@";
+
+inline constexpr std::string_view LicenseShort =
+    "License GPLv3 (GNU General Public License version 3)";
+inline constexpr std::string_view LicenseLong =
+    "For detailed license information, see LICENSE (GNU GPLv3) "
+    "<https://www.gnu.org/licenses/gpl-3.0.html>";
+
+} // namespace boyboy::version

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -8,10 +8,12 @@
 #include "boyboy/app/app.h"
 
 #include <filesystem>
+#include <sstream>
 
 #include "boyboy/common/config/config.h"
 #include "boyboy/common/config/config_utils.h"
 #include "boyboy/common/log/logging.h"
+#include "boyboy/version.h"
 
 namespace boyboy::app {
 
@@ -51,6 +53,32 @@ common::config::Config& App::load_config(std::optional<std::string_view> config_
 
     config_ = config::load_config(path);
     return config_;
+}
+
+std::string App::version()
+{
+    std::ostringstream oss;
+    oss << "BoyBoy version " << version::VersionStr << " (commit " << version::GitCommit << ")\n"
+        << version::LicenseShort << "\n"
+        << "Build type: " << version::BuildType << "\n"
+        << "Compiler: " << version::CompilerID << " " << version::CompilerVersion;
+
+    return oss.str();
+}
+
+std::string App::build_info()
+{
+    std::ostringstream oss;
+    oss << "BoyBoy version " << version::VersionStr << " (commit " << version::GitCommit
+        << ", branch " << version::GitBranch << ", tag " << version::GitTag << ")\n"
+        << version::LicenseShort << "\n"
+        << "Build type:     " << version::BuildType << "\n"
+        << "Compiler:       " << version::CompilerID << " " << version::CompilerVersion << "\n"
+        << "System:         " << version::SystemName << " (" << version::SystemProcessor << ")\n"
+        << "CMake version:  " << version::CmakeVersion << "\n"
+        << "Build timestamp:" << version::BuildTimestamp;
+
+    return oss.str();
 }
 
 } // namespace boyboy::app

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file app.cpp
+ * @brief Main application class for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/app/app.h"
+
+#include <filesystem>
+
+#include "boyboy/common/config/config_utils.h"
+#include "boyboy/common/log/logging.h"
+
+namespace boyboy::app {
+
+using namespace boyboy::common;
+
+int App::run(std::string_view rom_path, std::string_view config_path)
+{
+    log::info("Running BoyBoy emulator...");
+
+    // Load configuration
+    load_config(config_path);
+
+    // Apply configuration
+    emulator_.apply_config(config_);
+
+    // Load ROM
+    try {
+        emulator_.load(std::string(rom_path));
+    }
+    catch (const std::runtime_error& e) {
+        log::error("Failed to load ROM: {}", e.what());
+        return 1;
+    }
+
+    // Run emulator
+    emulator_.run();
+
+    log::info("Exiting BoyBoy emulator");
+
+    return 0;
+}
+
+void App::load_config(std::string_view config_path)
+{
+    // Load configuration from file if provided, otherwise use defaults
+    std::optional<std::filesystem::path> path;
+    if (!config_path.empty()) {
+        path = std::filesystem::path(config_path);
+    }
+
+    config_ = config::load_config(path);
+}
+
+[[nodiscard]] const config::Config& App::get_config() const
+{
+    return config_;
+}
+
+} // namespace boyboy::app

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 
+#include "boyboy/common/config/config.h"
 #include "boyboy/common/config/config_utils.h"
 #include "boyboy/common/log/logging.h"
 
@@ -16,12 +17,9 @@ namespace boyboy::app {
 
 using namespace boyboy::common;
 
-int App::run(std::string_view rom_path, std::string_view config_path)
+int App::run(std::string_view rom_path)
 {
     log::info("Running BoyBoy emulator...");
-
-    // Load configuration
-    load_config(config_path);
 
     // Apply configuration
     emulator_.apply_config(config_);
@@ -43,19 +41,15 @@ int App::run(std::string_view rom_path, std::string_view config_path)
     return 0;
 }
 
-void App::load_config(std::string_view config_path)
+common::config::Config& App::load_config(std::optional<std::string_view> config_path)
 {
     // Load configuration from file if provided, otherwise use defaults
-    std::optional<std::filesystem::path> path;
-    if (!config_path.empty()) {
-        path = std::filesystem::path(config_path);
+    std::optional<std::filesystem::path> path = std::nullopt;
+    if (config_path && !(*config_path).empty()) {
+        path = std::filesystem::path(*config_path);
     }
 
     config_ = config::load_config(path);
-}
-
-[[nodiscard]] const config::Config& App::get_config() const
-{
     return config_;
 }
 

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -13,6 +13,8 @@
 #include "boyboy/common/config/config.h"
 #include "boyboy/common/config/config_utils.h"
 #include "boyboy/common/log/logging.h"
+#include "boyboy/core/cartridge/cartridge.h"
+#include "boyboy/core/cartridge/cartridge_loader.h"
 #include "boyboy/version.h"
 
 namespace boyboy::app {
@@ -53,6 +55,12 @@ common::config::Config& App::load_config(std::optional<std::string_view> config_
 
     config_ = config::load_config(path);
     return config_;
+}
+
+std::string App::rom_info(std::string_view rom_path)
+{
+    auto cart = core::cartridge::CartridgeLoader::load(rom_path);
+    return cart.get_header().pretty_string();
 }
 
 std::string App::version()

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -8,6 +8,7 @@
 #include "boyboy/app/app.h"
 
 #include <filesystem>
+#include <optional>
 #include <sstream>
 
 #include "boyboy/common/config/config.h"
@@ -20,6 +21,16 @@
 namespace boyboy::app {
 
 using namespace boyboy::common;
+
+namespace {
+std::optional<std::filesystem::path> get_fs_path(std::optional<std::string_view> path)
+{
+    if (path && !(*path).empty()) {
+        return std::filesystem::path(*path);
+    }
+    return std::nullopt;
+}
+} // namespace
 
 int App::run(std::string_view rom_path)
 {
@@ -47,14 +58,18 @@ int App::run(std::string_view rom_path)
 
 common::config::Config& App::load_config(std::optional<std::string_view> config_path)
 {
-    // Load configuration from file if provided, otherwise use defaults
-    std::optional<std::filesystem::path> path = std::nullopt;
-    if (config_path && !(*config_path).empty()) {
-        path = std::filesystem::path(*config_path);
-    }
-
+    std::optional<std::filesystem::path> path = get_fs_path(config_path);
     config_ = config::load_config(path);
     return config_;
+}
+
+void App::save_config( // NOLINT
+    const common::config::Config& config,
+    std::optional<std::string_view> config_path
+)
+{
+    std::optional<std::filesystem::path> path = get_fs_path(config_path);
+    config::save_config(config, path);
 }
 
 std::string App::rom_info(std::string_view rom_path)

--- a/src/boyboy/app/commands/config_command.cpp
+++ b/src/boyboy/app/commands/config_command.cpp
@@ -1,0 +1,96 @@
+/**
+ * @file config_command.cpp
+ * @brief Config command for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/app/commands/config_command.h"
+
+#include <iostream>
+#include <stdexcept>
+
+#include "boyboy/app/app.h"
+#include "boyboy/app/commands/command_registry.h"
+#include "boyboy/common/config/config.h"
+
+namespace boyboy::app::commands {
+
+namespace {
+REGISTER_COMMAND(ConfigCommand);
+}
+
+int ConfigCommand::execute(App& app, const CommandContext& context)
+{
+    switch (subcommand_) {
+        case SubCommand::Get:
+            return execute_get(app, context);
+        case SubCommand::Set:
+            return execute_set(app, context);
+        case SubCommand::List:
+            return execute_list(app, context);
+        case SubCommand::Reset:
+            return execute_reset(app, context);
+        default:
+            break;
+    }
+
+    return 1;
+}
+
+int ConfigCommand::execute_get(App& app, const CommandContext& context)
+{
+    if (!key_) {
+        return 1;
+    }
+
+    auto& config = app.load_config(context.config_path);
+    try {
+        std::cout << config.key_value_str(*key_) << "\n";
+        return 0;
+    }
+    catch (const std::invalid_argument& e) {
+        std::cerr << "Error retrieving key " << *key_ << ": " << e.what() << "\n";
+    }
+
+    return 1;
+}
+int ConfigCommand::execute_set(App& app, const CommandContext& context)
+{
+    if (!key_ || !value_) {
+        return 1;
+    }
+
+    auto& config = app.load_config(context.config_path);
+    try {
+        config.set_string(*key_, *value_);
+        app.save_config(config, context.config_path);
+        std::cout << config.key_value_str(*key_) << "\n";
+        return 0;
+    }
+    catch (const std::invalid_argument& e) {
+        std::cerr << "Error setting key " << *key_ << ": " << e.what() << "\n";
+    }
+
+    return 1;
+}
+
+int ConfigCommand::execute_list(App& app, const CommandContext& context) // NOLINT
+{
+    auto& config = app.load_config(context.config_path);
+    for (const auto& key : common::config::ConfigKeys::KeyList) {
+        std::cout << config.key_value_str(key) << "\n";
+    }
+
+    return 0;
+}
+
+int ConfigCommand::execute_reset(App& app, const CommandContext& context) // NOLINT
+{
+    auto config = common::config::Config::default_config();
+    app.save_config(config, context.config_path);
+    std::cout << "Resetted configuration to default" << "\n";
+    return 0;
+}
+
+} // namespace boyboy::app::commands

--- a/src/boyboy/app/commands/info_command.cpp
+++ b/src/boyboy/app/commands/info_command.cpp
@@ -1,0 +1,37 @@
+/**
+ * @file info_command.cpp
+ * @brief Info command for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/app/commands/info_command.h"
+
+#include <iostream>
+#include <string>
+
+#include "boyboy/app/app.h"
+#include "boyboy/app/commands/command_registry.h"
+#include "boyboy/common/log/logging.h"
+
+namespace boyboy::app::commands {
+
+namespace {
+REGISTER_COMMAND(InfoCommand);
+}
+
+int InfoCommand::execute([[maybe_unused]] App& app, const CommandContext& context)
+{
+    try {
+        common::log::set_level(common::log::LogLevel::Off); // disable logging for info command
+        std::string info = App::rom_info(context.rom_path);
+        std::cout << info << "\n";
+        return 0;
+    }
+    catch (const std::runtime_error& e) {
+        std::cerr << "Failed to load ROM: " << e.what() << "\n";
+        return 1;
+    }
+}
+
+} // namespace boyboy::app::commands

--- a/src/boyboy/app/commands/run_command.cpp
+++ b/src/boyboy/app/commands/run_command.cpp
@@ -1,0 +1,18 @@
+/**
+ * @file run_command.cpp
+ * @brief Run command for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/app/commands/run_command.h"
+
+#include "boyboy/app/commands/command_registry.h"
+
+namespace boyboy::app::commands {
+
+namespace {
+REGISTER_COMMAND(RunCommand);
+}
+
+} // namespace boyboy::app::commands

--- a/src/boyboy/app/commands/run_command.cpp
+++ b/src/boyboy/app/commands/run_command.cpp
@@ -8,11 +8,34 @@
 #include "boyboy/app/commands/run_command.h"
 
 #include "boyboy/app/commands/command_registry.h"
+#include "boyboy/common/config/config_validator.h"
 
 namespace boyboy::app::commands {
 
 namespace {
 REGISTER_COMMAND(RunCommand);
+}
+
+int RunCommand::execute(App& app, const CommandContext& context)
+{
+    auto& config = app.load_config(context.config_path);
+    if (context.scale) {
+        config.video.scale = *context.scale;
+    }
+    if (context.speed) {
+        config.emulator.speed = *context.speed;
+    }
+    if (context.vsync) {
+        config.video.vsync = *context.vsync;
+    }
+    if (context.log_level) {
+        config.debug.log_level = *context.log_level;
+    }
+
+    auto result = common::config::ConfigValidator::validate(config, true);
+    common::config::ConfigValidator::check_result(result);
+
+    return app.run(context.rom_path);
 }
 
 } // namespace boyboy::app::commands

--- a/src/boyboy/app/commands/run_command.cpp
+++ b/src/boyboy/app/commands/run_command.cpp
@@ -19,18 +19,10 @@ REGISTER_COMMAND(RunCommand);
 int RunCommand::execute(App& app, const CommandContext& context)
 {
     auto& config = app.load_config(context.config_path);
-    if (context.scale) {
-        config.video.scale = *context.scale;
-    }
-    if (context.speed) {
-        config.emulator.speed = *context.speed;
-    }
-    if (context.vsync) {
-        config.video.vsync = *context.vsync;
-    }
-    if (context.log_level) {
-        config.debug.log_level = *context.log_level;
-    }
+    config.video.scale = scale_.value_or(config.video.scale);
+    config.emulator.speed = speed_.value_or(config.emulator.speed);
+    config.video.vsync = vsync_.value_or(config.video.vsync);
+    config.debug.log_level = context.log_level.value_or(config.debug.log_level);
 
     auto result = common::config::ConfigValidator::validate(config, true);
     common::config::ConfigValidator::check_result(result);

--- a/src/boyboy/common/config/config_utils.cpp
+++ b/src/boyboy/common/config/config_utils.cpp
@@ -13,6 +13,7 @@
 
 #include "boyboy/common/config/config.h"
 #include "boyboy/common/config/config_loader.h"
+#include "boyboy/common/config/config_validator.h"
 #include "boyboy/common/log/logging.h"
 
 namespace boyboy::common::config {
@@ -22,6 +23,12 @@ using ConfigLoader = TomlConfigLoader;
 Config load_config(const std::optional<std::filesystem::path>& path, bool normalize)
 {
     namespace fs = std::filesystem;
+
+    if (!path.has_value()) {
+        log::info(
+            "No configuration file provided, using default path: {}", default_config_path().string()
+        );
+    }
 
     auto file_path = path.value_or(default_config_path());
     if (!fs::exists(file_path)) {
@@ -66,6 +73,12 @@ void save_config(const Config& config, const std::optional<std::filesystem::path
 
     ConfigLoader loader{};
     loader.save(config, file);
+}
+
+void validate_config(Config& config, bool normalize)
+{
+    auto result = ConfigValidator::validate(config, normalize);
+    ConfigValidator::check_result(result);
 }
 
 std::filesystem::path default_config_path()

--- a/src/boyboy/common/config/config_validator.cpp
+++ b/src/boyboy/common/config/config_validator.cpp
@@ -11,6 +11,7 @@
 
 #include "boyboy/common/config/config.h"
 #include "boyboy/common/config/config_limits.h"
+#include "boyboy/common/log/logging.h"
 
 namespace boyboy::common::config {
 
@@ -39,6 +40,19 @@ ValidationResult ConfigValidator::validate(Config& config, bool normalize)
     );
 
     return result;
+}
+
+void ConfigValidator::check_result(const ValidationResult& result)
+{
+    if (!result.valid) {
+        for (const auto& error : result.errors) {
+            log::error("Config error: {}", error);
+        }
+        throw std::runtime_error("Configuration validation failed");
+    }
+    for (const auto& warning : result.warnings) {
+        log::warn("Config warning: {}", warning);
+    }
 }
 
 template <typename Limit, typename Value>

--- a/src/boyboy/common/config/toml_config_loader.cpp
+++ b/src/boyboy/common/config/toml_config_loader.cpp
@@ -77,15 +77,7 @@ const toml::table& get_section(const toml::table& tbl, std::string_view section)
 
     // Validate and normalize config
     auto result = ConfigValidator::validate(config, normalize);
-    if (!result.valid) {
-        for (const auto& error : result.errors) {
-            log::error("Config error: {}", error);
-        }
-        throw std::runtime_error("Configuration validation failed");
-    }
-    for (const auto& warning : result.warnings) {
-        log::warn("Config warning: {}", warning);
-    }
+    ConfigValidator::check_result(result);
 
     return config;
 }

--- a/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
+++ b/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
@@ -17,6 +17,7 @@
 namespace boyboy::frontend::cli {
 
 inline static constexpr std::string_view RunCommandName = "run";
+inline static constexpr std::string_view InfoCommandName = "info";
 
 CLI11Adapter::CLI11Adapter(app::App& app, app::commands::CommandContext& context)
     : app_(app), context_(context)
@@ -50,6 +51,9 @@ void CLI11Adapter::register_command(app::commands::ICommand& command)
 {
     if (command.name() == RunCommandName) {
         register_run(command);
+    }
+    else if (command.name() == InfoCommandName) {
+        register_info(command);
     }
     else {
         throw std::runtime_error(
@@ -122,6 +126,23 @@ void CLI11Adapter::register_run(app::commands::ICommand& command)
     )
         ->option_text("LEVEL")
         ->check(CLI::IsMember(common::config::ConfigLimits::Debug::LogLevels));
+
+    cmd->callback([this, &command]() { command.execute(app_, context_); });
+}
+
+void CLI11Adapter::register_info(app::commands::ICommand& command)
+{
+    auto* cmd = app_parser_.add_subcommand(
+        std::string(command.name()), std::string(command.description())
+    );
+    cmd->footer(R"(
+        Examples:
+          boyboy info path/to/rom.gb
+    )");
+
+    cmd->add_option("rom", context_.rom_path, "Path to the ROM file")
+        ->option_text("ROM_PATH")
+        ->required();
 
     cmd->callback([this, &command]() { command.execute(app_, context_); });
 }

--- a/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
+++ b/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file cli11_adapter.cpp
+ * @brief CLI11 adapter for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/frontend/cli/adapters/cli11_adapter.h"
+
+#include "CLI/CLI.hpp"
+
+namespace boyboy::frontend::cli {
+
+inline static constexpr std::string_view RunCommandName = "run";
+
+CLI11Adapter::CLI11Adapter(app::commands::CommandContext& context) : context_(context)
+{
+    app_parser_.name("boyboy");
+    app_parser_.description("BoyBoy - A Game Boy emulator");
+    app_parser_.set_help_flag("-h,--help", "Print help message and exit");
+    app_parser_.set_help_all_flag("--help-all", "Print all help messages and exit");
+    app_parser_.require_subcommand(1);
+}
+
+int CLI11Adapter::run(std::span<std::string_view> args)
+{
+    parse(args);
+    return 0;
+}
+
+void CLI11Adapter::register_command(app::commands::ICommand& command)
+{
+    if (command.name() == RunCommandName) {
+        register_run(command);
+    }
+    else {
+        throw std::runtime_error(
+            std::string("Unsupported command: ") + std::string(command.name())
+        );
+    }
+}
+
+void CLI11Adapter::parse(std::span<std::string_view> args)
+{
+    std::vector<const char*> argv;
+    for (const auto& arg : args) {
+        argv.push_back(arg.data());
+    }
+
+    try {
+        app_parser_.parse(static_cast<int>(argv.size()), argv.data());
+    }
+    catch (const CLI::ParseError& e) {
+        app_parser_.exit(e);
+    }
+}
+
+void CLI11Adapter::register_run(app::commands::ICommand& command)
+{
+    auto* cmd = app_parser_.add_subcommand(
+        std::string(command.name()), std::string(command.description())
+    );
+    cmd->add_option("rom", context_.rom_path, "Path to the ROM file")
+        ->option_text("ROM_PATH")
+        ->required();
+    cmd->add_option("-c,--config", context_.config_path, "Path to the configuration file")
+        ->option_text("CONFIG_PATH")
+        ->default_val("");
+    cmd->callback([this, &command]() { command.execute(context_); });
+}
+
+} // namespace boyboy::frontend::cli

--- a/src/boyboy/frontend/cli/cli_app.cpp
+++ b/src/boyboy/frontend/cli/cli_app.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file cli_app.cpp
+ * @brief Command line interface application for the BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/frontend/cli/cli_app.h"
+
+#include "boyboy/app/commands/command_registry.h"
+#include "boyboy/frontend/cli/adapters/cli11_adapter.h"
+
+namespace boyboy::frontend::cli {
+
+using CLIAdapter = CLI11Adapter;
+
+CLIApp::CLIApp() : context_(), cli_adapter_(std::make_unique<CLIAdapter>(context_)) {}
+
+int CLIApp::run(std::span<std::string_view> args)
+{
+    setup_commands();
+    return cli_adapter_->run(args);
+}
+
+void CLIApp::setup_commands()
+{
+    auto& registry = app::commands::CommandRegistry::instance();
+    registry.register_all(*cli_adapter_);
+}
+
+} // namespace boyboy::frontend::cli

--- a/src/boyboy/frontend/cli/cli_app.cpp
+++ b/src/boyboy/frontend/cli/cli_app.cpp
@@ -14,7 +14,7 @@ namespace boyboy::frontend::cli {
 
 using CLIAdapter = CLI11Adapter;
 
-CLIApp::CLIApp() : context_(), cli_adapter_(std::make_unique<CLIAdapter>(context_)) {}
+CLIApp::CLIApp() : cli_adapter_(std::make_unique<CLIAdapter>(app_, context_)) {}
 
 int CLIApp::run(std::span<std::string_view> args)
 {

--- a/src/boyboy/main.cpp
+++ b/src/boyboy/main.cpp
@@ -5,50 +5,29 @@
  * @license GPLv3 (see LICENSE file)
  */
 
-#include <iostream>
 #include <span>
-#include <stdexcept>
+#include <string_view>
 
-#include "boyboy/common/config/config.h"
-#include "boyboy/common/config/config_utils.h"
 #include "boyboy/common/log/logging.h"
-#include "boyboy/core/emulator/emulator.h"
+#include "boyboy/frontend/cli/cli_app.h"
 
 using namespace boyboy::common;
-using namespace boyboy::core;
+using namespace boyboy::frontend::cli;
 
 int main(int argc, const char** argv)
 {
-    std::span<const char*> args(argv, static_cast<std::size_t>(argc));
-
-    if (args.size() != 2) {
-        std::cout << "Usage: " << args[0] << " <path_to_rom>\n";
-        return 1;
+    // Convert argv to vector of string_view for better handling
+    std::vector<std::string_view> args;
+    for (const auto* s : std::span(argv, static_cast<std::size_t>(argc))) {
+        args.emplace_back(s);
     }
 
     log::init("logs/boyboy.log", true);
-    log::info("Starting BoyBoy emulator");
 
-    emulator::Emulator emulator;
+    CLIApp app{};
+    int res = app.run(args);
 
-    // Load and apply configuration
-    config::Config config = config::load_config();
-    emulator.apply_config(config);
-
-    // Load ROM
-    try {
-        emulator.load(args[1]);
-    }
-    catch (const std::runtime_error& e) {
-        log::error("Failed to load ROM: {}", e.what());
-        return 1;
-    }
-
-    // Run emulator
-    emulator.run();
-
-    log::info("Exiting BoyBoy emulator");
     log::shutdown();
 
-    return 0;
+    return res;
 }

--- a/src/boyboy/main.cpp
+++ b/src/boyboy/main.cpp
@@ -18,16 +18,16 @@ int main(int argc, const char** argv)
 {
     // Convert argv to vector of string_view for better handling
     std::vector<std::string_view> args;
-    for (const auto* s : std::span(argv, static_cast<std::size_t>(argc))) {
-        args.emplace_back(s);
+    for (const auto* arg : std::span(argv, static_cast<std::size_t>(argc))) {
+        args.emplace_back(arg);
     }
 
     log::init("logs/boyboy.log", true);
 
     CLIApp app{};
-    int res = app.run(args);
+    int result = app.run(args);
 
     log::shutdown();
 
-    return res;
+    return result;
 }


### PR DESCRIPTION
## Summary

Improve the emulator command line interface integrating CLI11, allowing more complex argument parsing and more options.

## Added

**Command execution:**
- Frontend-independant command execution system:
  - `App` executor class
  - `ICommand` interface and `CommandContext` for information passing
  - `CommandRegistry` for command registration
- Concrete commands:
  - `RunCommand` for emulator running
  - `InfoCommand` for ROM information
  - `ConfigCommand` for viewing and editing configuration

**Command Line Interface:**
- CLI application `CLIApp` running an abstract CLI adapter `ICLIAdapter` 
- Concrete CLI11 adapter implementation `CLI11Adapter`
- Run command with config, speed, scale, vsync and log level options
- Info command to display ROM metadata information
- Config with key-value get and set, and full configuration list and reset
- Version and build information

## Changed

- Main application entry point modified to use `CLIApp`
- Add `validate_config` method to config utils
- Add `check_result` method to `ConfigValidator`
- Add key-value access to `Config`