### PR TITLE
Battery-backed RAM saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Changed
 
 - Improve MMU memory mapping with read-only and unmapped regions.
-- Refactor MMU ROM and ERAM mapping logic to use MBC interface.
+- Refactor MMU ROM and SRAM mapping logic to use MBC interface.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- **Files Module** with general file I/O handling and shared file paths and utilities
+  - Text files read and write: `read_text()` and `write_text()`
+  - Binary files read and write: `read_binary()` and `write_binary()`
+  - Stream handling: `input_stream()` and `output_stream`
+  - Atomic operations: `atomic_write()`
+  - Shared utilities and validation: `paths.h`, `errors.h` and `utils.h`
+- **SRAM save and load** functionality for battery-backed RAM MBC chips
+  - `SaveManager` for save and load handling
+  - Load save file on start and save to file on periodic intervals and shutdown
+- **Config** options for save files:
+  - `saves.autosave` for enabling/disabling autosave
+  - `saves.save_interval` for configuring autosave interval
+- **CLI** options for save files:
+  - `--save-path` for custom saving path
+  - `--autosave` for enabling/disabling autosave
+  - `--save-interval` for setting autosave interval
+
+### Changed
+
+- `config_utils` and `CartridgeLoader` now use `files` module for files operations
+- `CartridgeLoader` now returns a `unique_ptr` to `Cartridge`
+- Rename `ERAM` to `SRAM`
+- CLI and configuration improvements
+
 ---
 
 ## [0.5.0] - 2025-10-16

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ target_sources(${BOYBOY_LIB} PRIVATE
     src/boyboy/common/config/config_utils.cpp
     src/boyboy/common/config/config_validator.cpp
     src/boyboy/common/config/toml_config_loader.cpp
+    src/boyboy/common/save/save_manager.cpp
     src/boyboy/core/cpu/cpu.cpp
     src/boyboy/core/cpu/instructions.cpp
     src/boyboy/core/cpu/instructions_table.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(${BOYBOY_LIB} STATIC)
 target_sources(${BOYBOY_LIB} PRIVATE
     src/boyboy/common/utils.cpp
     src/boyboy/common/files/utils.cpp
+    src/boyboy/common/files/io.cpp
     src/boyboy/common/config/config_utils.cpp
     src/boyboy/common/config/config_validator.cpp
     src/boyboy/common/config/toml_config_loader.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ endif()
 add_library(${BOYBOY_LIB} STATIC)
 target_sources(${BOYBOY_LIB} PRIVATE
     src/boyboy/common/utils.cpp
+    src/boyboy/common/files/utils.cpp
     src/boyboy/common/config/config_utils.cpp
     src/boyboy/common/config/config_validator.cpp
     src/boyboy/common/config/toml_config_loader.cpp

--- a/include/boyboy/app/app.h
+++ b/include/boyboy/app/app.h
@@ -41,6 +41,9 @@ public:
     [[nodiscard]] const common::config::Config& get_config() const { return config_; }
     [[nodiscard]] common::config::Config& get_config() { return config_; }
 
+    // Save configuration
+    void set_battery_save_path(std::string_view save_path);
+
     // ROM information
     [[nodiscard]] static std::string rom_info(std::string_view rom_path);
 

--- a/include/boyboy/app/commands/run_command.h
+++ b/include/boyboy/app/commands/run_command.h
@@ -28,6 +28,12 @@ public:
     void set_scale(std::optional<int> scale) { scale_ = scale; }
     [[nodiscard]] std::optional<bool> get_vsync() const { return vsync_; }
     void set_vsync(std::optional<bool> vsync) { vsync_ = vsync; }
+    [[nodiscard]] std::optional<std::string> get_save_path() const { return save_path_; }
+    void set_save_path(std::optional<std::string> save_path) { save_path_ = std::move(save_path); }
+    [[nodiscard]] std::optional<bool> get_autosave() const { return autosave_; }
+    void set_autosave(std::optional<bool> autosave) { autosave_ = autosave; }
+    [[nodiscard]] std::optional<int> get_save_interval_ms() const { return save_interval_ms_; }
+    void set_save_interval_ms(std::optional<int> interval_ms) { save_interval_ms_ = interval_ms; }
 
 private:
     static constexpr std::string_view Name = "run";
@@ -36,6 +42,9 @@ private:
     std::optional<int> scale_;
     std::optional<int> speed_;
     std::optional<bool> vsync_;
+    std::optional<std::string> save_path_;
+    std::optional<bool> autosave_;
+    std::optional<int> save_interval_ms_;
 };
 
 } // namespace boyboy::app::commands

--- a/include/boyboy/common/config/config.h
+++ b/include/boyboy/common/config/config.h
@@ -5,6 +5,9 @@
  * @license GPLv3 (see LICENSE file)
  */
 
+// TODO: improve config system
+// Right now we have to touch 1000 places to add/modify a single config key
+
 #pragma once
 
 #include <concepts>
@@ -35,6 +38,11 @@ struct ConfigKeys {
         static constexpr std::string_view Scale = "scale";
         static constexpr std::string_view VSync = "vsync";
     };
+    struct Battery {
+        static constexpr std::string_view Section = "battery";
+        static constexpr std::string_view Autosave = "autosave";
+        static constexpr std::string_view IntervalMs = "interval_ms";
+    };
     struct Debug {
         static constexpr std::string_view Section = "debug";
         static constexpr std::string_view LogLevel = "log_level";
@@ -47,6 +55,10 @@ struct ConfigKeys {
                                                  std::string(Video::Scale);
     inline static const std::string VideoVSync = std::string(Video::Section) + "." +
                                                  std::string(Video::VSync);
+    inline static const std::string BatteryAutoSave = std::string(Battery::Section) + "." +
+                                                      std::string(Battery::Autosave);
+    inline static const std::string BatteryIntervalMs = std::string(Battery::Section) + "." +
+                                                        std::string(Battery::IntervalMs);
     inline static const std::string DebugLogLevel = std::string(Debug::Section) + "." +
                                                     std::string(Debug::LogLevel);
 
@@ -54,6 +66,8 @@ struct ConfigKeys {
         EmulatorSpeed,
         VideoScale,
         VideoVSync,
+        BatteryAutoSave,
+        BatteryIntervalMs,
         DebugLogLevel,
     };
 };
@@ -72,6 +86,8 @@ private:
         {ConfigKeys::EmulatorSpeed, Type::Int},
         {ConfigKeys::VideoScale, Type::Int},
         {ConfigKeys::VideoVSync, Type::Bool},
+        {ConfigKeys::BatteryAutoSave, Type::Bool},
+        {ConfigKeys::BatteryIntervalMs, Type::Int},
         {ConfigKeys::DebugLogLevel, Type::String},
     };
 };
@@ -86,6 +102,11 @@ struct Config {
         int scale = ConfigLimits::Video::ScaleRange.default_value;
         bool vsync = true;
     } video; // NOLINT
+
+    struct Battery {
+        bool autosave = true;
+        int interval_ms = ConfigLimits::Battery::IntervalMsRange.default_value;
+    } battery; // NOLINT
 
     struct Debug {
         std::string log_level = std::string(ConfigLimits::Debug::LogLevelOptions.default_value);
@@ -185,6 +206,12 @@ private:
          }}},
         {ConfigKeys::VideoVSync, ConfigAccessor{[](Config& c) {
              return &c.video.vsync;
+         }}},
+        {ConfigKeys::BatteryAutoSave, ConfigAccessor{[](Config& c) {
+             return &c.battery.autosave;
+         }}},
+        {ConfigKeys::BatteryIntervalMs, ConfigAccessor{[](Config& c) {
+             return &c.battery.interval_ms;
          }}},
         {ConfigKeys::DebugLogLevel, ConfigAccessor{[](Config& c) {
              return &c.debug.log_level;

--- a/include/boyboy/common/config/config.h
+++ b/include/boyboy/common/config/config.h
@@ -38,10 +38,10 @@ struct ConfigKeys {
         static constexpr std::string_view Scale = "scale";
         static constexpr std::string_view VSync = "vsync";
     };
-    struct Battery {
-        static constexpr std::string_view Section = "battery";
+    struct Saves {
+        static constexpr std::string_view Section = "saves";
         static constexpr std::string_view Autosave = "autosave";
-        static constexpr std::string_view IntervalMs = "interval_ms";
+        static constexpr std::string_view SaveInterval = "save_interval";
     };
     struct Debug {
         static constexpr std::string_view Section = "debug";
@@ -55,10 +55,10 @@ struct ConfigKeys {
                                                  std::string(Video::Scale);
     inline static const std::string VideoVSync = std::string(Video::Section) + "." +
                                                  std::string(Video::VSync);
-    inline static const std::string BatteryAutoSave = std::string(Battery::Section) + "." +
-                                                      std::string(Battery::Autosave);
-    inline static const std::string BatteryIntervalMs = std::string(Battery::Section) + "." +
-                                                        std::string(Battery::IntervalMs);
+    inline static const std::string SavesAutoSave = std::string(Saves::Section) + "." +
+                                                    std::string(Saves::Autosave);
+    inline static const std::string SavesSaveInterval = std::string(Saves::Section) + "." +
+                                                        std::string(Saves::SaveInterval);
     inline static const std::string DebugLogLevel = std::string(Debug::Section) + "." +
                                                     std::string(Debug::LogLevel);
 
@@ -66,8 +66,8 @@ struct ConfigKeys {
         EmulatorSpeed,
         VideoScale,
         VideoVSync,
-        BatteryAutoSave,
-        BatteryIntervalMs,
+        SavesAutoSave,
+        SavesSaveInterval,
         DebugLogLevel,
     };
 };
@@ -86,8 +86,8 @@ private:
         {ConfigKeys::EmulatorSpeed, Type::Int},
         {ConfigKeys::VideoScale, Type::Int},
         {ConfigKeys::VideoVSync, Type::Bool},
-        {ConfigKeys::BatteryAutoSave, Type::Bool},
-        {ConfigKeys::BatteryIntervalMs, Type::Int},
+        {ConfigKeys::SavesAutoSave, Type::Bool},
+        {ConfigKeys::SavesSaveInterval, Type::Int},
         {ConfigKeys::DebugLogLevel, Type::String},
     };
 };
@@ -103,10 +103,10 @@ struct Config {
         bool vsync = true;
     } video; // NOLINT
 
-    struct Battery {
+    struct Saves {
         bool autosave = true;
-        int interval_ms = ConfigLimits::Battery::IntervalMsRange.default_value;
-    } battery; // NOLINT
+        int save_interval = ConfigLimits::Saves::SaveInterval.default_value;
+    } saves; // NOLINT
 
     struct Debug {
         std::string log_level = std::string(ConfigLimits::Debug::LogLevelOptions.default_value);
@@ -207,11 +207,11 @@ private:
         {ConfigKeys::VideoVSync, ConfigAccessor{[](Config& c) {
              return &c.video.vsync;
          }}},
-        {ConfigKeys::BatteryAutoSave, ConfigAccessor{[](Config& c) {
-             return &c.battery.autosave;
+        {ConfigKeys::SavesAutoSave, ConfigAccessor{[](Config& c) {
+             return &c.saves.autosave;
          }}},
-        {ConfigKeys::BatteryIntervalMs, ConfigAccessor{[](Config& c) {
-             return &c.battery.interval_ms;
+        {ConfigKeys::SavesSaveInterval, ConfigAccessor{[](Config& c) {
+             return &c.saves.save_interval;
          }}},
         {ConfigKeys::DebugLogLevel, ConfigAccessor{[](Config& c) {
              return &c.debug.log_level;

--- a/include/boyboy/common/config/config_limits.h
+++ b/include/boyboy/common/config/config_limits.h
@@ -49,6 +49,12 @@ struct ConfigLimits {
         static constexpr Range<int> ScaleRange = {.min = 1, .max = 10, .default_value = 4};
     };
 
+    struct Battery {
+        static constexpr Range<int> IntervalMsRange = {
+            .min = 0, .max = 3'600'000, .default_value = 5000
+        };
+    };
+
     struct Debug {
         static constexpr std::array<std::string_view, 7> LogLevels = {
             "trace", "debug", "info", "warn", "error", "critical", "off"

--- a/include/boyboy/common/config/config_limits.h
+++ b/include/boyboy/common/config/config_limits.h
@@ -46,11 +46,11 @@ struct ConfigLimits {
     };
 
     struct Video {
-        static constexpr Range<int> ScaleRange = {.min = 1, .max = 10, .default_value = 4};
+        static constexpr Range<int> ScaleRange = {.min = 1, .max = 10, .default_value = 2};
     };
 
-    struct Battery {
-        static constexpr Range<int> IntervalMsRange = {
+    struct Saves {
+        static constexpr Range<int> SaveInterval = {
             .min = 0, .max = 3'600'000, .default_value = 5000
         };
     };

--- a/include/boyboy/common/config/config_utils.h
+++ b/include/boyboy/common/config/config_utils.h
@@ -9,22 +9,16 @@
 
 #include <filesystem>
 #include <optional>
-#include <string_view>
 
 #include "boyboy/common/config/config.h"
 
 namespace boyboy::common::config {
 
-inline constexpr std::string_view DefaultConfigDir = "boyboy";
-inline constexpr std::string_view DefaultConfigFile = "config.toml";
+// alias for shorter signature
+using OptionalPath = std::optional<std::filesystem::path>;
 
-Config
-load_config(const std::optional<std::filesystem::path>& path = std::nullopt, bool normalize = true);
-void save_config(
-    const Config& config, const std::optional<std::filesystem::path>& path = std::nullopt
-);
+Config load_config(const OptionalPath& path = {}, bool normalize = true);
+void save_config(const Config& config, const OptionalPath& path = {});
 void validate_config(Config& config, bool normalize = true);
-
-std::filesystem::path default_config_path();
 
 } // namespace boyboy::common::config

--- a/include/boyboy/common/files/errors.h
+++ b/include/boyboy/common/files/errors.h
@@ -1,0 +1,69 @@
+/**
+ * @file errors.h
+ * @brief File errors definitions.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace boyboy::common::files {
+
+struct FileError {
+    enum class Type : uint8_t {
+        NotFound,
+        PermissionDenied,
+        IsDirectory,
+        BadMode,
+        ReadError,
+        WriteError,
+        Unknown,
+    } type;
+
+    std::filesystem::path path;
+    std::optional<std::string> message;
+
+    FileError(Type t, std::filesystem::path p = {}, std::optional<std::string> m = {})
+        : type(t), path(std::move(p)), message(std::move(m)) {};
+
+    // Error type to string
+    static const char* to_string(Type e)
+    {
+        switch (e) {
+            case Type::NotFound:
+                return "File not found";
+            case Type::PermissionDenied:
+                return "Permission denied";
+            case Type::IsDirectory:
+                return "Path is a directory";
+            case Type::BadMode:
+                return "Bad open mode";
+            case Type::ReadError:
+                return "Read error";
+            case Type::WriteError:
+                return "Write error";
+            case Type::Unknown:
+                return "Unknown file error";
+        }
+    }
+
+    // Compose full human-readable error message
+    [[nodiscard]] std::string error_message() const
+    {
+        std::string err_msg = "[" + std::string(to_string(type)) + "]";
+        if (!path.empty()) {
+            err_msg += " " + path.string();
+        }
+        if (message) {
+            err_msg += ": " + *message;
+        }
+        return err_msg;
+    }
+};
+
+} // namespace boyboy::common::files

--- a/include/boyboy/common/files/errors.h
+++ b/include/boyboy/common/files/errors.h
@@ -22,6 +22,7 @@ struct FileError {
         BadMode,
         ReadError,
         WriteError,
+        IOError,
         Unknown,
     } type;
 
@@ -47,6 +48,8 @@ struct FileError {
                 return "Read error";
             case Type::WriteError:
                 return "Write error";
+            case Type::IOError:
+                return "IO Error";
             default:
                 return "Unknown file error";
         }

--- a/include/boyboy/common/files/errors.h
+++ b/include/boyboy/common/files/errors.h
@@ -47,7 +47,7 @@ struct FileError {
                 return "Read error";
             case Type::WriteError:
                 return "Write error";
-            case Type::Unknown:
+            default:
                 return "Unknown file error";
         }
     }

--- a/include/boyboy/common/files/io.h
+++ b/include/boyboy/common/files/io.h
@@ -1,0 +1,94 @@
+/**
+ * @file io.h
+ * @brief Input/Output file operations.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "boyboy/common/files/errors.h"
+
+namespace boyboy::common::files {
+
+// ---------- Text file operations ----------
+
+/**
+ * @brief Reads a text file and returns its contents.
+ *
+ * @param path Path to the text file to read.
+ * @return std::expected<std::string, FileError> File content or FileError on error.
+ */
+[[nodiscard]] auto read_text(const std::filesystem::path& path)
+    -> std::expected<std::string, FileError>;
+
+/**
+ * @brief Write data to a text file.
+ *
+ * @param path Path to the text file to write.
+ * @param data Data to write to the file.
+ * @param trunc Whether it should truncate the file.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto write_text(const std::filesystem::path& path, std::string_view data, bool trunc = true)
+    -> std::expected<void, FileError>;
+
+// ---------- Binary file operations ----------
+
+/**
+ * @brief Reads a binary file and returns its contents.
+ *
+ * @param path Path to the binary file to read.
+ * @return std::expected<std::vector<std::byte>, FileError> File content or FileError on error.
+ */
+[[nodiscard]] auto read_binary(const std::filesystem::path& path)
+    -> std::expected<std::vector<std::byte>, FileError>;
+
+/**
+ * @brief Write data to a binary file.
+ *
+ * @param path Path to the binary file to write.
+ * @param data Data to write to the file.
+ * @param trunc Whether it should truncate the file.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto write_binary(
+    const std::filesystem::path& path, std::span<const std::byte> data, bool trunc = true
+) -> std::expected<void, FileError>;
+
+// ---------- Stream operations ----------
+
+/**
+ * @brief Opens an input stream for reading.
+ *
+ * Mode is always appended with std::ios::in, regardless of the given mode.
+ *
+ * @param path Path to the file to open.
+ * @param mode File open mode.
+ * @return std::expected<std::ifstream, FileError> Input stream or FileError on error.
+ */
+auto input_stream(const std::filesystem::path& path, std::ios::openmode mode = {})
+    -> std::expected<std::ifstream, FileError>;
+
+/**
+ * @brief Opens an output stream for writing.
+ *
+ * Mode is always appended with std::ios::out, regardless of the given mode.
+ *
+ * @param path Path to the file to open.
+ * @param mode File open mode.
+ * @return std::expected<std::ofstream, FileError> Output stream or FileError on error.
+ */
+auto output_stream(const std::filesystem::path& path, std::ios::openmode mode = {})
+    -> std::expected<std::ofstream, FileError>;
+
+} // namespace boyboy::common::files

--- a/include/boyboy/common/files/paths.h
+++ b/include/boyboy/common/files/paths.h
@@ -1,0 +1,36 @@
+/**
+ * @file paths.h
+ * @brief Filesystem paths for configuration, data, and cache.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <filesystem>
+
+namespace boyboy::common::files {
+
+static constexpr std::filesystem::path get_xdg_path(const char* env, const char* fallback);
+
+// Base directories
+constexpr auto BoyBoyDir = "boyboy";
+const auto ConfigDir = get_xdg_path("XDG_CONFIG_HOME", ".config") / BoyBoyDir;
+const auto DataDir = get_xdg_path("XDG_DATA_HOME", ".local/share") / BoyBoyDir;
+const auto CacheDir = get_xdg_path("XDG_CACHE_HOME", ".cache") / BoyBoyDir;
+
+static constexpr std::filesystem::path get_xdg_path(const char* env, const char* fallback)
+{
+    if (const auto* xdg = std::getenv(env)) {
+        return xdg;
+    }
+    if (const auto* home = std::getenv("HOME")) {
+        return std::filesystem::path(home) / fallback;
+    }
+
+    // if neither is set, point fallback to current dir
+    return fallback;
+}
+
+} // namespace boyboy::common::files

--- a/include/boyboy/common/files/utils.h
+++ b/include/boyboy/common/files/utils.h
@@ -1,0 +1,145 @@
+/**
+ * @file utils.h
+ * @brief File utilities and validations.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+
+#include "boyboy/common/files/errors.h"
+
+namespace boyboy::common::files {
+
+// Run multiple validations at once
+template <typename... CheckFns>
+std::expected<void, FileError> run_checks(CheckFns... checks)
+{
+    for (auto& check : {checks()...}) {
+        if (!check) {
+            return check;
+        }
+    }
+    return {};
+}
+
+// ---------- Validation methods ----------
+
+/**
+ * @brief Validates a file path.
+ *
+ * Path is considered valid if it contains or could contain a regular file. I.e. if it's not an
+ * existent directory.
+ *
+ * @param path Path to validate.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto validate_file(const std::filesystem::path& path) -> std::expected<void, FileError>;
+
+/**
+ * @brief Validates a path.
+ *
+ * Path is considered valid if it passes validate_file and also is an existent path. I.e. file
+ * exists and is not a directory.
+ *
+ * @param path Path to validate.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto validate_path(const std::filesystem::path& path) -> std::expected<void, FileError>;
+
+/**
+ * @brief Validates a file open mode.
+ *
+ * Mode is considered valid if it contains all expected modes.
+ *
+ * @param mode Mode(s) to validate.
+ * @param expected Expected mode(s) in mode.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto validate_mode(std::ios::openmode mode, std::ios::openmode expected)
+    -> std::expected<void, FileError>;
+
+/**
+ * @brief Validates file permissions with the corresponding open mode.
+ *
+ * Checks if an input open mode has read permissions or if an output open mode has write
+ * permissions.
+ * Additionally, it checks that the user running the app has permissions to that path.
+ *
+ * Notes:
+ * - Other mode other than std::ios::in or std::ios::out are considered FileError:Type::BadMode
+ * - A non existent path will return as valid. It's up to the user to check the permissions of the
+ * parent path where the is to be created.
+ *
+ * @param path Path to validate.
+ * @param mode Mode to open the file (std::ios::in, std::ios::out).
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto validate_permissions(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<void, FileError>;
+
+/**
+ * @brief Ensures that the parent directory exists.
+ *
+ * Checks if the parent dir exists. If it does not, it creates recursively all parent directories.
+ * If parent dir already exists it does nothing.
+ *
+ * @param path Path which parent directory needs to be ensured.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto ensure_parent_dir(const std::filesystem::path& path) -> std::expected<void, FileError>;
+
+/**
+ * @brief Ensures a path is readable in the given mode.
+ *
+ * The path must correspond to an existent file, with read permissions for the running user.
+ * Mode must include std::ios::in.
+ *
+ * It performs the following checks:
+ * - validate_path
+ * - validate_mode
+ * - validate_permissions
+ *
+ * @param path Path to ensure is readable.
+ * @param mode Mode to open the path.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto ensure_readable(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<void, FileError>;
+
+/**
+ * @brief Ensures a path is writable in the given mode.
+ *
+ * The path must be a writable or creatable file. If the parent directory of the file does not
+ * exist, it is created recursively.
+ * Mode must be std::ios::out.
+ *
+ * It performs the following checks:
+ * - validate_file
+ * - validate_mode
+ * - ensure_parent_dir
+ * - validate_permissions
+ *
+ * @param path Path to ensure is writable.
+ * @param mode Mode to open the path.
+ * @return std::expected<void, FileError> Nothing or FileError on error.
+ */
+auto ensure_writable(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<void, FileError>;
+
+// ---------- File utility functions ----------
+
+/**
+ * @brief Gets the size of a file stream.
+ *
+ * @param stream Input file stream.
+ * @return std::uintmax_t Size of the stream.
+ */
+std::uintmax_t stream_size(std::ifstream& stream);
+
+} // namespace boyboy::common::files

--- a/include/boyboy/common/save/save_manager.h
+++ b/include/boyboy/common/save/save_manager.h
@@ -1,0 +1,58 @@
+/**
+ * @file save_manager.h
+ * @brief Save Manager for BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace boyboy::core::cartridge {
+class Cartridge;
+}
+
+namespace boyboy::common::save {
+
+class SaveManager {
+public:
+    /** @brief Save ERAM data to disk.
+     *
+     * @param rom_title Title of the ROM (used to determine save file path)
+     * @param data Span of ERAM data to save
+     * @param save_path Optional custom save file path
+     * @return std::expected<void, std::string> Empty on success, error message on failure
+     */
+    static auto save_eram(
+        std::string_view rom_title,
+        std::span<const uint8_t> data,
+        const std::optional<std::filesystem::path>& save_path = {}
+    ) -> std::expected<void, std::string>;
+
+    /** @brief Load ERAM data from disk.
+     *
+     * @param rom_title Title of the ROM (used to determine save file path)
+     * @param save_path Optional custom save file path
+     * @return std::expected<std::vector<uint8_t>, std::string> Loaded ERAM data on success, error
+     * message on failure
+     */
+    static auto load_eram(
+        std::string_view rom_title, const std::optional<std::filesystem::path>& save_path = {}
+    ) -> std::expected<std::vector<uint8_t>, std::string>;
+
+private:
+    static std::filesystem::path eram_path(std::string_view rom_title);
+    static uint16_t checksum(std::span<const uint8_t> data);
+    [[nodiscard]] static uint16_t read_checksum(std::span<const std::byte> buf);
+    static void write_checksum(std::span<std::byte> buf, uint16_t cks);
+};
+
+} // namespace boyboy::common::save

--- a/include/boyboy/common/save/save_manager.h
+++ b/include/boyboy/common/save/save_manager.h
@@ -24,6 +24,16 @@ namespace boyboy::common::save {
 
 class SaveManager {
 public:
+    /** @brief Get the singleton instance of SaveManager.
+     *
+     * @return SaveManager& Reference to the singleton SaveManager instance.
+     */
+    [[nodiscard]] static SaveManager& instance()
+    {
+        static SaveManager inst;
+        return inst;
+    }
+
     /** @brief Save ERAM data to disk.
      *
      * @param rom_title Title of the ROM (used to determine save file path)
@@ -31,7 +41,7 @@ public:
      * @param save_path Optional custom save file path
      * @return std::expected<void, std::string> Empty on success, error message on failure
      */
-    static auto save_eram(
+    auto save_eram(
         std::string_view rom_title,
         std::span<const uint8_t> data,
         const std::optional<std::filesystem::path>& save_path = {}
@@ -44,11 +54,19 @@ public:
      * @return std::expected<std::vector<uint8_t>, std::string> Loaded ERAM data on success, error
      * message on failure
      */
-    static auto load_eram(
+    auto load_eram(
         std::string_view rom_title, const std::optional<std::filesystem::path>& save_path = {}
     ) -> std::expected<std::vector<uint8_t>, std::string>;
 
+    /** @brief Set custom ERAM save file path.
+     *
+     * @param save_path Custom save file path
+     */
+    void set_eram_save_path(const std::filesystem::path& save_path) { eram_save_path_ = save_path; }
+
 private:
+    std::optional<std::filesystem::path> eram_save_path_;
+
     static std::filesystem::path eram_path(std::string_view rom_title);
     static uint16_t checksum(std::span<const uint8_t> data);
     [[nodiscard]] static uint16_t read_checksum(std::span<const std::byte> buf);

--- a/include/boyboy/common/save/save_manager.h
+++ b/include/boyboy/common/save/save_manager.h
@@ -34,40 +34,40 @@ public:
         return inst;
     }
 
-    /** @brief Save ERAM data to disk.
+    /** @brief Save SRAM data to disk.
      *
      * @param rom_title Title of the ROM (used to determine save file path)
-     * @param data Span of ERAM data to save
+     * @param data Span of SRAM data to save
      * @param save_path Optional custom save file path
      * @return std::expected<void, std::string> Empty on success, error message on failure
      */
-    auto save_eram(
+    auto save_sram(
         std::string_view rom_title,
         std::span<const uint8_t> data,
         const std::optional<std::filesystem::path>& save_path = {}
     ) -> std::expected<void, std::string>;
 
-    /** @brief Load ERAM data from disk.
+    /** @brief Load SRAM data from disk.
      *
      * @param rom_title Title of the ROM (used to determine save file path)
      * @param save_path Optional custom save file path
-     * @return std::expected<std::vector<uint8_t>, std::string> Loaded ERAM data on success, error
+     * @return std::expected<std::vector<uint8_t>, std::string> Loaded SRAM data on success, error
      * message on failure
      */
-    auto load_eram(
+    auto load_sram(
         std::string_view rom_title, const std::optional<std::filesystem::path>& save_path = {}
     ) -> std::expected<std::vector<uint8_t>, std::string>;
 
-    /** @brief Set custom ERAM save file path.
+    /** @brief Set custom SRAM save file path.
      *
      * @param save_path Custom save file path
      */
-    void set_eram_save_path(const std::filesystem::path& save_path) { eram_save_path_ = save_path; }
+    void set_sram_save_path(const std::filesystem::path& save_path) { sram_save_path_ = save_path; }
 
 private:
-    std::optional<std::filesystem::path> eram_save_path_;
+    std::optional<std::filesystem::path> sram_save_path_;
 
-    static std::filesystem::path eram_path(std::string_view rom_title);
+    static std::filesystem::path sram_path(std::string_view rom_title);
     static uint16_t checksum(std::span<const uint8_t> data);
     [[nodiscard]] static uint16_t read_checksum(std::span<const std::byte> buf);
     static void write_checksum(std::span<std::byte> buf, uint16_t cks);

--- a/include/boyboy/common/utils.h
+++ b/include/boyboy/common/utils.h
@@ -71,4 +71,20 @@ std::string printable_char(char c);
 char* as_char_ptr(std::byte* ptr) noexcept;
 const char* as_char_ptr(const std::byte* ptr) noexcept;
 
+// String utils
+
+/**
+ * @brief Normalize a ROM title to be safe to use in file paths.
+ *
+ * Performs the following transformations:
+ * - Converts to lowercase
+ * - Removes apostrophes (')
+ * - Replaces non-alphanumeric characters with underscores
+ * - Ensures there are no duplicated nor trailing underscores
+ *
+ * @param rom_title ROM title to normalize.
+ * @return std::string Normalized ROM title.
+ */
+std::string normalize_rom_title(std::string_view rom_title);
+
 } // namespace boyboy::common::utils

--- a/include/boyboy/core/cartridge/cartridge.h
+++ b/include/boyboy/core/cartridge/cartridge.h
@@ -147,6 +147,10 @@ public:
     void set_ram(auto ram) { mbc_.set_ram(ram); }
     void set_ram_load_cb(RamLoadCb&& cb) { on_ram_load_cb_ = std::move(cb); }
     void set_ram_save_cb(RamSaveCb&& cb) { on_ram_save_cb_ = std::move(cb); }
+    [[nodiscard]] bool is_autosave_enabled() const { return autosave_enabled_; }
+    void enable_autosave(bool enable) { autosave_enabled_ = enable; }
+    [[nodiscard]] uint32_t get_save_interval_ms() const { return mbc_.get_save_interval_ms(); }
+    void set_save_interval_ms(uint32_t interval_ms) { mbc_.set_save_interval_ms(interval_ms); }
 
     // Accessors
     [[nodiscard]] const RomData& get_rom_data() const { return rom_data_; }
@@ -168,6 +172,7 @@ private:
     mbc::Mbc mbc_;
     RomData rom_data_;
     bool rom_loaded_ = false;
+    bool autosave_enabled_ = true;
 
     // RAM load/save callbacks
     RamLoadCb on_ram_load_cb_ = nullptr;

--- a/include/boyboy/core/cartridge/cartridge_loader.h
+++ b/include/boyboy/core/cartridge/cartridge_loader.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string_view>
 #include <vector>
 
@@ -17,9 +18,9 @@ using RomData = std::vector<std::byte>;
 
 class CartridgeLoader {
 public:
-    static Cartridge load(std::string_view path);
-    static Cartridge load(RomData&& rom_data);
-    static Cartridge load(const RomData& rom_data);
+    static std::unique_ptr<Cartridge> load(std::string_view path);
+    static std::unique_ptr<Cartridge> load(RomData&& rom_data);
+    static std::unique_ptr<Cartridge> load(const RomData& rom_data);
 
 private:
     static RomData load_rom_data(std::string_view path);

--- a/include/boyboy/core/cartridge/mbc.h
+++ b/include/boyboy/core/cartridge/mbc.h
@@ -90,7 +90,8 @@ public:
         save_pending_ = false;
         last_save_ = BatteryClock::now();
     }
-    void set_save_period(uint32_t period_ms) { save_period_ms_ = period_ms; };
+    [[nodiscard]] uint32_t get_save_interval_ms() const { return save_interval_ms_; }
+    void set_save_interval_ms(uint32_t interval_ms) { save_interval_ms_ = interval_ms; }
 
     // Accessors
     [[nodiscard]] MbcType get_type() const { return type_; }
@@ -113,7 +114,7 @@ public:
 
 private:
     using BatteryClock = std::chrono::steady_clock;
-    static constexpr uint32_t DefaultSavePeriodMs = 5000;
+    static constexpr uint32_t DefaultSaveIntervalMs = 5000;
 
     // MBC status and information
     MbcType type_{MbcType::None};
@@ -122,7 +123,7 @@ private:
     bool has_battery_{false};
     bool eram_dirty_{false};
     bool save_pending_{false};
-    uint32_t save_period_ms_ = DefaultSavePeriodMs;
+    uint32_t save_interval_ms_ = DefaultSaveIntervalMs;
     BatteryClock::time_point last_save_{BatteryClock::now()};
 
     // MBC registers

--- a/include/boyboy/core/cartridge/mbc.h
+++ b/include/boyboy/core/cartridge/mbc.h
@@ -7,7 +7,7 @@
  * ------------------------------------- MBC1 Registers ------------------------------------
  * 0x0000-0x1FFF - RAM Enable (Write Only)
  *                 0x0A - Enable RAM
- *                 Must be enabled before writing to ERAM
+ *                 Must be enabled before writing to SRAM
  * 0x2000-0x3FFF - ROM Bank Number (Write Only)
  *                 Lower 5 bits select the ROM bank number (0-31), higher bits discarded
  *                 Writing 0 selects bank 1 instead (0 is fixed)
@@ -75,7 +75,7 @@ public:
     [[nodiscard]] uint8_t read(uint16_t addr) const;
     void write(uint16_t addr, uint8_t value);
 
-    // Full ERAM data access
+    // Full SRAM data access
     [[nodiscard]] std::vector<uint8_t> get_ram() const;
     void set_ram(std::span<const uint8_t> ram);
 
@@ -86,7 +86,7 @@ public:
     [[nodiscard]] bool is_save_pending() const { return save_pending_; };
     void clear_save()
     {
-        eram_dirty_ = false;
+        sram_dirty_ = false;
         save_pending_ = false;
         last_save_ = BatteryClock::now();
     }
@@ -121,7 +121,7 @@ private:
 
     // Battery status
     bool has_battery_{false};
-    bool eram_dirty_{false};
+    bool sram_dirty_{false};
     bool save_pending_{false};
     uint32_t save_interval_ms_ = DefaultSaveIntervalMs;
     BatteryClock::time_point last_save_{BatteryClock::now()};

--- a/include/boyboy/core/emulator/emulator.h
+++ b/include/boyboy/core/emulator/emulator.h
@@ -56,7 +56,7 @@ private:
     ppu::Ppu& ppu_ = io_.ppu();
     io::Joypad& joypad_ = io_.joypad();
     display::Display display_;
-    cartridge::Cartridge cartridge_;
+    std::unique_ptr<cartridge::Cartridge> cartridge_;
 
     // Emulator state
     bool running_ = false;

--- a/include/boyboy/core/mmu/constants.h
+++ b/include/boyboy/core/mmu/constants.h
@@ -25,8 +25,8 @@ static constexpr uint16_t ROMEnd = ROMBank1End;
 static constexpr uint16_t VRAMStart = 0x8000;
 static constexpr uint16_t VRAMEnd = 0x9FFF;
 
-static constexpr uint16_t ERAMStart = 0xA000;
-static constexpr uint16_t ERAMEnd = 0xBFFF;
+static constexpr uint16_t SRAMStart = 0xA000;
+static constexpr uint16_t SRAMEnd = 0xBFFF;
 
 static constexpr uint16_t WRAM0Start = 0xC000;
 static constexpr uint16_t WRAM0End = 0xCFFF;
@@ -57,7 +57,7 @@ static constexpr size_t ROMBank0Size = ROMBank0End - ROMBank0Start + 1;
 static constexpr size_t ROMBank1Size = ROMBank1End - ROMBank1Start + 1;
 static constexpr size_t ROMBankSize = ROMBank0Size + ROMBank1Size;
 static constexpr size_t VRAMSize = VRAMEnd - VRAMStart + 1;
-static constexpr size_t ERAMSize = ERAMEnd - ERAMStart + 1;
+static constexpr size_t SRAMSize = SRAMEnd - SRAMStart + 1;
 static constexpr size_t WRAM0Size = WRAM0End - WRAM0Start + 1;
 static constexpr size_t WRAM1Size = WRAM1End - WRAM1Start + 1;
 static constexpr size_t WRAMSize = WRAM0Size + WRAM1Size;

--- a/include/boyboy/core/mmu/mmu.h
+++ b/include/boyboy/core/mmu/mmu.h
@@ -80,7 +80,7 @@ private:
         ROMBank0 = 0,
         ROMBank1,
         VRAM,
-        ERAM,
+        SRAM,
         WRAM0,
         WRAM1,
         ECHO,

--- a/include/boyboy/frontend/cli/adapters/cli11_adapter.h
+++ b/include/boyboy/frontend/cli/adapters/cli11_adapter.h
@@ -33,6 +33,9 @@ private:
         std::optional<int> scale;
         std::optional<int> speed;
         std::optional<bool> vsync;
+        std::optional<std::string> save_path;
+        std::optional<bool> autosave;
+        std::optional<int> save_interval_ms;
         // Config
         std::optional<std::string> cfg_key;
         std::optional<std::string> cfg_value;

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -75,7 +75,7 @@ void App::save_config( // NOLINT
 
 void App::set_battery_save_path(std::string_view save_path) // NOLINT
 {
-    save::SaveManager::instance().set_eram_save_path(save_path);
+    save::SaveManager::instance().set_sram_save_path(save_path);
 }
 
 std::string App::rom_info(std::string_view rom_path)

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -75,7 +75,7 @@ void App::save_config( // NOLINT
 std::string App::rom_info(std::string_view rom_path)
 {
     auto cart = core::cartridge::CartridgeLoader::load(rom_path);
-    return cart.get_header().pretty_string();
+    return cart->get_header().pretty_string();
 }
 
 std::string App::version()

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -14,6 +14,7 @@
 #include "boyboy/common/config/config.h"
 #include "boyboy/common/config/config_utils.h"
 #include "boyboy/common/log/logging.h"
+#include "boyboy/common/save/save_manager.h"
 #include "boyboy/core/cartridge/cartridge.h"
 #include "boyboy/core/cartridge/cartridge_loader.h"
 #include "boyboy/version.h"
@@ -70,6 +71,11 @@ void App::save_config( // NOLINT
 {
     std::optional<std::filesystem::path> path = get_fs_path(config_path);
     config::save_config(config, path);
+}
+
+void App::set_battery_save_path(std::string_view save_path) // NOLINT
+{
+    save::SaveManager::instance().set_eram_save_path(save_path);
 }
 
 std::string App::rom_info(std::string_view rom_path)

--- a/src/boyboy/app/app.cpp
+++ b/src/boyboy/app/app.cpp
@@ -36,9 +36,6 @@ int App::run(std::string_view rom_path)
 {
     log::info("Running BoyBoy emulator...");
 
-    // Apply configuration
-    emulator_.apply_config(config_);
-
     // Load ROM
     try {
         emulator_.load(std::string(rom_path));
@@ -47,6 +44,9 @@ int App::run(std::string_view rom_path)
         log::error("Failed to load ROM: {}", e.what());
         return 1;
     }
+
+    // Apply configuration
+    emulator_.apply_config(config_);
 
     // Run emulator
     emulator_.run();

--- a/src/boyboy/app/commands/run_command.cpp
+++ b/src/boyboy/app/commands/run_command.cpp
@@ -23,8 +23,8 @@ int RunCommand::execute(App& app, const CommandContext& context)
     config.emulator.speed = speed_.value_or(config.emulator.speed);
     config.video.vsync = vsync_.value_or(config.video.vsync);
     config.debug.log_level = context.log_level.value_or(config.debug.log_level);
-    config.battery.autosave = autosave_.value_or(config.battery.autosave);
-    config.battery.interval_ms = save_interval_ms_.value_or(config.battery.interval_ms);
+    config.saves.autosave = autosave_.value_or(config.saves.autosave);
+    config.saves.save_interval = save_interval_ms_.value_or(config.saves.save_interval);
 
     auto result = common::config::ConfigValidator::validate(config, true);
     common::config::ConfigValidator::check_result(result);

--- a/src/boyboy/app/commands/run_command.cpp
+++ b/src/boyboy/app/commands/run_command.cpp
@@ -23,9 +23,15 @@ int RunCommand::execute(App& app, const CommandContext& context)
     config.emulator.speed = speed_.value_or(config.emulator.speed);
     config.video.vsync = vsync_.value_or(config.video.vsync);
     config.debug.log_level = context.log_level.value_or(config.debug.log_level);
+    config.battery.autosave = autosave_.value_or(config.battery.autosave);
+    config.battery.interval_ms = save_interval_ms_.value_or(config.battery.interval_ms);
 
     auto result = common::config::ConfigValidator::validate(config, true);
     common::config::ConfigValidator::check_result(result);
+
+    if (save_path_) {
+        app.set_battery_save_path(*save_path_);
+    }
 
     return app.run(context.rom_path);
 }

--- a/src/boyboy/common/config/config_utils.cpp
+++ b/src/boyboy/common/config/config_utils.cpp
@@ -9,11 +9,12 @@
 
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 
 #include "boyboy/common/config/config.h"
 #include "boyboy/common/config/config_loader.h"
 #include "boyboy/common/config/config_validator.h"
+#include "boyboy/common/files/errors.h"
+#include "boyboy/common/files/io.h"
 #include "boyboy/common/files/paths.h"
 #include "boyboy/common/log/logging.h"
 
@@ -26,8 +27,6 @@ using ConfigLoader = TomlConfigLoader;
 
 Config load_config(const OptionalPath& path, bool normalize)
 {
-    namespace fs = std::filesystem;
-
     if (!path.has_value()) {
         log::info(
             "No configuration file provided, using default path: {}", DefaultConfigPath.string()
@@ -35,21 +34,17 @@ Config load_config(const OptionalPath& path, bool normalize)
     }
 
     auto file_path = path.value_or(DefaultConfigPath);
-    if (!fs::exists(file_path)) {
-        log::warn("Configuration file not found, using default config: {}", file_path.string());
-        return Config::default_config();
-    }
-
-    std::ifstream file(file_path);
-    if (!file.is_open()) {
-        log::error(
-            "Failed to open configuration file, using default config: {}", file_path.string()
+    auto file = files::input_stream(file_path);
+    if (!file) {
+        log::warn(
+            "Failed to open configuration file, using default config: {}",
+            file.error().error_message()
         );
         return Config::default_config();
     }
 
     ConfigLoader loader{};
-    return loader.load(file, normalize);
+    return loader.load(*file, normalize);
 }
 
 void save_config(const Config& config, const OptionalPath& path)
@@ -57,26 +52,21 @@ void save_config(const Config& config, const OptionalPath& path)
     namespace fs = std::filesystem;
 
     auto file_path = path.value_or(DefaultConfigPath);
-    if (auto parent_path = file_path.parent_path(); !parent_path.empty()) {
-        // ensure parent dir exists
-        fs::create_directories(parent_path);
-    }
-
     if (!fs::exists(file_path)) {
         log::info("Configuration file does not exist, creating new one: {}", file_path.string());
     }
     else {
-        log::info("Overwriting configuration file: {}", file_path.string());
+        log::warn("Overwriting configuration file: {}", file_path.string());
     }
 
-    std::ofstream file(file_path, std::ios::out | std::ios::trunc);
-    if (!file.is_open()) {
-        log::error("Failed to open configuration file: {}", file_path.string());
+    auto file = files::output_stream(file_path);
+    if (!file) {
+        log::error("Failed to open configuration file: {}", file.error().error_message());
         return;
     }
 
     ConfigLoader loader{};
-    loader.save(config, file);
+    loader.save(config, *file);
 }
 
 void validate_config(Config& config, bool normalize)

--- a/src/boyboy/common/config/config_validator.cpp
+++ b/src/boyboy/common/config/config_validator.cpp
@@ -33,6 +33,14 @@ ValidationResult ConfigValidator::validate(Config& config, bool normalize)
 
     validate_field(
         result,
+        config.battery.interval_ms,
+        ConfigLimits::Battery::IntervalMsRange,
+        "battery.interval_ms",
+        normalize
+    );
+
+    validate_field(
+        result,
         config.debug.log_level,
         ConfigLimits::Debug::LogLevelOptions,
         "debug.log_level",

--- a/src/boyboy/common/config/config_validator.cpp
+++ b/src/boyboy/common/config/config_validator.cpp
@@ -23,7 +23,7 @@ ValidationResult ConfigValidator::validate(Config& config, bool normalize)
         result,
         config.emulator.speed,
         ConfigLimits::Emulator::SpeedRange,
-        "emulator.speed",
+        ConfigKeys::EmulatorSpeed,
         normalize
     );
 
@@ -33,9 +33,9 @@ ValidationResult ConfigValidator::validate(Config& config, bool normalize)
 
     validate_field(
         result,
-        config.battery.interval_ms,
-        ConfigLimits::Battery::IntervalMsRange,
-        "battery.interval_ms",
+        config.saves.save_interval,
+        ConfigLimits::Saves::SaveInterval,
+        ConfigKeys::SavesSaveInterval,
         normalize
     );
 
@@ -43,7 +43,7 @@ ValidationResult ConfigValidator::validate(Config& config, bool normalize)
         result,
         config.debug.log_level,
         ConfigLimits::Debug::LogLevelOptions,
-        "debug.log_level",
+        ConfigKeys::DebugLogLevel,
         normalize
     );
 

--- a/src/boyboy/common/config/toml_config_loader.cpp
+++ b/src/boyboy/common/config/toml_config_loader.cpp
@@ -70,6 +70,20 @@ const toml::table& get_section(const toml::table& tbl, std::string_view section)
     load_field(config.video.scale, video_tbl, ConfigKeys::Video::Scale, ConfigKeys::Video::Section);
     load_field(config.video.vsync, video_tbl, ConfigKeys::Video::VSync, ConfigKeys::Video::Section);
 
+    auto battery_tbl = get_section(tbl, ConfigKeys::Battery::Section);
+    load_field(
+        config.battery.autosave,
+        battery_tbl,
+        ConfigKeys::Battery::Autosave,
+        ConfigKeys::Battery::Section
+    );
+    load_field(
+        config.battery.interval_ms,
+        battery_tbl,
+        ConfigKeys::Battery::IntervalMs,
+        ConfigKeys::Battery::Section
+    );
+
     auto debug_tbl = get_section(tbl, ConfigKeys::Debug::Section);
     load_field(
         config.debug.log_level, debug_tbl, ConfigKeys::Debug::LogLevel, ConfigKeys::Debug::Section
@@ -92,6 +106,10 @@ void TomlConfigLoader::save(const Config& config, std::ostream& output) const
         {ConfigKeys::Video::Scale, config.video.scale},
         {ConfigKeys::Video::VSync, config.video.vsync},
     };
+    auto battery_tbl = toml::table{
+        {ConfigKeys::Battery::Autosave, config.battery.autosave},
+        {ConfigKeys::Battery::IntervalMs, config.battery.interval_ms},
+    };
     auto debug_tbl = toml::table{
         {ConfigKeys::Debug::LogLevel, std::string(config.debug.log_level)},
     };
@@ -99,6 +117,7 @@ void TomlConfigLoader::save(const Config& config, std::ostream& output) const
     auto config_tbl = toml::table{
         {ConfigKeys::Emulator::Section, emulator_tbl},
         {ConfigKeys::Video::Section, video_tbl},
+        {ConfigKeys::Battery::Section, battery_tbl},
     };
 
     output << config_tbl << "\n\n";

--- a/src/boyboy/common/config/toml_config_loader.cpp
+++ b/src/boyboy/common/config/toml_config_loader.cpp
@@ -17,6 +17,43 @@
 
 namespace boyboy::common::config {
 
+// Global header comment
+inline static constexpr std::string_view ConfigHeader = R"(# BoyBoy Emulator Configuration File
+# ----------------------------------
+# This file contains configurable options for the BoyBoy Game Boy emulator.
+# Edit carefully. Lines starting with '#' are comments.
+#
+# Valid ranges and default values:
+#
+# [emulator] - core emulator settings
+#   speed: integer
+#       0 = uncapped
+#       1..10 = speed multiplier
+#       default: 1
+#
+# [saves] - save options
+#   autosave: true/false
+#       default: true
+#   save_interval: milliseconds
+#       0 = save on every write
+#       1..3600000 = save at the specified interval (1ms to 1 hour)
+#       default: 5000 (5 seconds)
+#
+# [video] - display and rendering options
+#   scale: integer
+#       1..10: scale factor
+#       default: 2
+#   vsync: true/false
+#       default: true
+#
+# [debug] - logging and debug options
+#   log_level: trace | debug | info | warn | error | critical | off
+#       default: info
+#
+# For more information and bug reports: https://github.com/sebdevnull/boyboy
+# License: GNU GPLv3 - https://www.gnu.org/licenses/gpl-3.0.html
+)";
+
 namespace {
 template <typename Field>
 void load_field(
@@ -70,18 +107,15 @@ const toml::table& get_section(const toml::table& tbl, std::string_view section)
     load_field(config.video.scale, video_tbl, ConfigKeys::Video::Scale, ConfigKeys::Video::Section);
     load_field(config.video.vsync, video_tbl, ConfigKeys::Video::VSync, ConfigKeys::Video::Section);
 
-    auto battery_tbl = get_section(tbl, ConfigKeys::Battery::Section);
+    auto battery_tbl = get_section(tbl, ConfigKeys::Saves::Section);
     load_field(
-        config.battery.autosave,
-        battery_tbl,
-        ConfigKeys::Battery::Autosave,
-        ConfigKeys::Battery::Section
+        config.saves.autosave, battery_tbl, ConfigKeys::Saves::Autosave, ConfigKeys::Saves::Section
     );
     load_field(
-        config.battery.interval_ms,
+        config.saves.save_interval,
         battery_tbl,
-        ConfigKeys::Battery::IntervalMs,
-        ConfigKeys::Battery::Section
+        ConfigKeys::Saves::SaveInterval,
+        ConfigKeys::Saves::Section
     );
 
     auto debug_tbl = get_section(tbl, ConfigKeys::Debug::Section);
@@ -107,8 +141,8 @@ void TomlConfigLoader::save(const Config& config, std::ostream& output) const
         {ConfigKeys::Video::VSync, config.video.vsync},
     };
     auto battery_tbl = toml::table{
-        {ConfigKeys::Battery::Autosave, config.battery.autosave},
-        {ConfigKeys::Battery::IntervalMs, config.battery.interval_ms},
+        {ConfigKeys::Saves::Autosave, config.saves.autosave},
+        {ConfigKeys::Saves::SaveInterval, config.saves.save_interval},
     };
     auto debug_tbl = toml::table{
         {ConfigKeys::Debug::LogLevel, std::string(config.debug.log_level)},
@@ -117,9 +151,10 @@ void TomlConfigLoader::save(const Config& config, std::ostream& output) const
     auto config_tbl = toml::table{
         {ConfigKeys::Emulator::Section, emulator_tbl},
         {ConfigKeys::Video::Section, video_tbl},
-        {ConfigKeys::Battery::Section, battery_tbl},
+        {ConfigKeys::Saves::Section, battery_tbl},
     };
 
+    output << ConfigHeader << "\n\n";
     output << config_tbl << "\n\n";
     output << toml::table{{ConfigKeys::Debug::Section, debug_tbl}} << "\n";
 }

--- a/src/boyboy/common/files/io.cpp
+++ b/src/boyboy/common/files/io.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file io.cpp
+ * @brief Input/Output file operations.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/common/files/io.h"
+
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <ios>
+#include <iterator>
+#include <string>
+
+#include "boyboy/common/files/errors.h"
+#include "boyboy/common/files/utils.h"
+
+namespace boyboy::common::files {
+
+[[nodiscard]] auto read_text(const std::filesystem::path& path)
+    -> std::expected<std::string, FileError>
+{
+    auto file = input_stream(path);
+    if (!file) {
+        return std::unexpected(file.error());
+    }
+
+    std::string buffer(
+        std::istreambuf_iterator<char>(file.value()), std::istreambuf_iterator<char>()
+    );
+
+    if (file->fail()) {
+        return std::unexpected(FileError{FileError::Type::ReadError, path});
+    }
+
+    return buffer;
+}
+
+auto write_text(const std::filesystem::path& path, std::string_view data, bool trunc)
+    -> std::expected<void, FileError>
+{
+    std::ios::openmode mode{};
+    if (trunc) {
+        mode |= std::ios::trunc;
+    }
+
+    auto file = output_stream(path, mode);
+    if (!file) {
+        return std::unexpected(file.error());
+    }
+
+    file->write(data.data(), static_cast<std::streamsize>(data.size()));
+    if (file->fail()) {
+        return std::unexpected(FileError{FileError::Type::WriteError, path});
+    }
+
+    return {};
+}
+
+[[nodiscard]] auto read_binary(const std::filesystem::path& path)
+    -> std::expected<std::vector<std::byte>, FileError>
+{
+    auto file = input_stream(path, std::ios::binary);
+    if (!file) {
+        return std::unexpected(file.error());
+    }
+
+    auto size = stream_size(file.value());
+    std::vector<std::byte> buffer(size);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    file->read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(size));
+
+    if (file->fail()) {
+        return std::unexpected(FileError{FileError::Type::ReadError, path});
+    }
+
+    return buffer;
+}
+
+auto write_binary(const std::filesystem::path& path, std::span<const std::byte> data, bool trunc)
+    -> std::expected<void, FileError>
+{
+    std::ios::openmode mode{std::ios::binary};
+    if (trunc) {
+        mode |= std::ios::trunc;
+    }
+
+    auto file = output_stream(path, mode);
+    if (!file) {
+        return std::unexpected(file.error());
+    }
+
+    file->write(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<const char*>(data.data()),
+        static_cast<std::streamsize>(data.size())
+    );
+    if (file->fail()) {
+        return std::unexpected(FileError{FileError::Type::WriteError, path});
+    }
+
+    return {};
+}
+
+auto input_stream(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<std::ifstream, FileError>
+{
+    mode |= std::ios::in;
+
+    if (auto err = ensure_readable(path, mode); !err) {
+        return std::unexpected(err.error());
+    }
+
+    std::ifstream file(path, mode);
+    if (!file.is_open()) {
+        return std::unexpected(
+            FileError{FileError::Type::Unknown, path, "Failed to open file for reading"}
+        );
+    }
+
+    return file;
+}
+
+auto output_stream(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<std::ofstream, FileError>
+{
+    mode |= std::ios::out;
+
+    if (auto err = ensure_writable(path, mode); !err) {
+        return std::unexpected(err.error());
+    }
+
+    std::ofstream file(path, mode);
+    if (!file.is_open()) {
+        return std::unexpected(
+            FileError{FileError::Type::Unknown, path, "Failed to open file for writing"}
+        );
+    }
+
+    return file;
+}
+
+} // namespace boyboy::common::files

--- a/src/boyboy/common/files/io.cpp
+++ b/src/boyboy/common/files/io.cpp
@@ -56,6 +56,8 @@ auto write_text(const std::filesystem::path& path, std::string_view data, bool t
         return std::unexpected(FileError{FileError::Type::WriteError, path});
     }
 
+    file->flush();
+
     return {};
 }
 
@@ -101,6 +103,8 @@ auto write_binary(const std::filesystem::path& path, std::span<const std::byte> 
     if (file->fail()) {
         return std::unexpected(FileError{FileError::Type::WriteError, path});
     }
+
+    file->flush();
 
     return {};
 }

--- a/src/boyboy/common/files/utils.cpp
+++ b/src/boyboy/common/files/utils.cpp
@@ -1,0 +1,141 @@
+/**
+ * @file utils.cpp
+ * @brief File utilities and validations.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/common/files/utils.h"
+
+#include <unistd.h>
+
+#include <expected>
+#include <filesystem>
+
+#include "boyboy/common/files/errors.h"
+
+namespace boyboy::common::files {
+
+auto validate_file(const std::filesystem::path& path) -> std::expected<void, FileError>
+{
+    if (std::filesystem::exists(path) && std::filesystem::is_directory(path)) {
+        return std::unexpected(FileError{FileError::Type::IsDirectory, path});
+    }
+
+    return {};
+}
+
+auto validate_path(const std::filesystem::path& path) -> std::expected<void, FileError>
+{
+    if (auto err = validate_file(path); !err) {
+        return err;
+    }
+
+    if (!std::filesystem::exists(path)) {
+        return std::unexpected(FileError{FileError::Type::NotFound, path});
+    }
+
+    return {};
+}
+
+auto validate_mode(std::ios::openmode mode, std::ios::openmode expected)
+    -> std::expected<void, FileError>
+{
+    if ((mode & expected) != expected) {
+        return std::unexpected(FileError{FileError::Type::BadMode});
+    }
+
+    return {};
+}
+
+auto validate_permissions(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<void, FileError>
+{
+    if (!std::filesystem::exists(path)) {
+        return {};
+    }
+
+    auto perms = std::filesystem::status(path).permissions();
+
+    if ((mode & std::ios::in) != 0) {
+        perms &=
+            (std::filesystem::perms::owner_read | std::filesystem::perms::group_read |
+             std::filesystem::perms::others_read);
+    }
+    else if ((mode & std::ios::out) != 0) {
+        perms &=
+            (std::filesystem::perms::owner_write | std::filesystem::perms::group_write |
+             std::filesystem::perms::others_write);
+    }
+    else {
+        return std::unexpected(FileError{FileError::Type::BadMode, path});
+    }
+
+    if (perms == std::filesystem::perms::none) {
+        return std::unexpected(FileError{FileError::Type::PermissionDenied, path});
+    }
+
+    // Check POSIX access for dirs
+    if (std::filesystem::is_directory(path)) {
+        if (((mode & std::ios::out) != 0) && ::access(path.c_str(), W_OK | X_OK) != 0) {
+            return std::unexpected(FileError{FileError::Type::PermissionDenied, path});
+        }
+        if (((mode & std::ios::in) != 0) && ::access(path.c_str(), R_OK | X_OK) != 0) {
+            return std::unexpected(FileError{FileError::Type::PermissionDenied, path});
+        }
+        return {};
+    }
+
+    // Check POSIX access for files
+    int amode = ((mode & std::ios::in) != 0 ? R_OK : 0) | ((mode & std::ios::out) != 0 ? W_OK : 0);
+    if (::access(path.c_str(), amode) != 0) {
+        return std::unexpected(FileError{FileError::Type::PermissionDenied, path});
+    }
+
+    return {};
+}
+
+auto ensure_parent_dir(const std::filesystem::path& path) -> std::expected<void, FileError>
+{
+    auto dir = path.parent_path();
+    if (!dir.empty() && !std::filesystem::exists(dir)) {
+        std::error_code ec;
+        if (!std::filesystem::create_directories(dir, ec)) {
+            return std::unexpected(FileError{FileError::Type::PermissionDenied, dir, ec.message()});
+        }
+    }
+
+    return {};
+}
+
+auto ensure_readable(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<void, FileError>
+{
+    return run_checks(
+        [&]() { return validate_path(path); },
+        [&]() { return validate_mode(mode, std::ios::in); },
+        [&]() { return validate_permissions(path, mode); }
+    );
+}
+
+auto ensure_writable(const std::filesystem::path& path, std::ios::openmode mode)
+    -> std::expected<void, FileError>
+{
+    return run_checks(
+        [&]() { return validate_file(path); },
+        [&]() { return validate_mode(mode, std::ios::out); },
+        [&]() { return ensure_parent_dir(path); },
+        [&]() { return validate_permissions(path, mode); }
+    );
+}
+
+std::uintmax_t stream_size(std::ifstream& stream)
+{
+    stream.seekg(0, std::ios::end);
+    std::uintmax_t size = stream.tellg();
+    stream.seekg(0, std::ios::beg);
+
+    return size;
+}
+
+} // namespace boyboy::common::files

--- a/src/boyboy/common/save/save_manager.cpp
+++ b/src/boyboy/common/save/save_manager.cpp
@@ -25,87 +25,87 @@ namespace boyboy::common::save {
 
 constexpr auto BatteryRamFile = "battery.sav";
 
-auto SaveManager::save_eram(
+auto SaveManager::save_sram(
     std::string_view rom_title,
     std::span<const uint8_t> data,
     const std::optional<std::filesystem::path>& save_path
 ) -> std::expected<void, std::string>
 {
-    auto file_path = save_path.value_or(eram_save_path_.value_or(eram_path(rom_title)));
-    log::debug("[SaveManager] Saving ERAM to: {}", file_path.string());
+    auto file_path = save_path.value_or(sram_save_path_.value_or(sram_path(rom_title)));
+    log::debug("[SaveManager] Saving SRAM to: {}", file_path.string());
 
     if (!std::filesystem::exists(file_path)) {
         log::debug(
-            "[SaveManager] ERAM save file does not exist, creating new one: {}", file_path.string()
+            "[SaveManager] SRAM save file does not exist, creating new one: {}", file_path.string()
         );
     }
 
     // Create a vector of bytes to append the checksum
-    std::vector<std::byte> eram_bytes{data.size() + 2}; // fit all data + checksum
-    std::ranges::transform(data.begin(), data.end(), eram_bytes.begin(), [](uint8_t b) {
+    std::vector<std::byte> sram_bytes{data.size() + 2}; // fit all data + checksum
+    std::ranges::transform(data.begin(), data.end(), sram_bytes.begin(), [](uint8_t b) {
         return std::byte{b};
     });
 
     // Calculate checksum and write to buffer
     uint16_t cks = checksum(data);
-    write_checksum(eram_bytes, cks);
+    write_checksum(sram_bytes, cks);
 
-    auto res = files::atomic_write(file_path, eram_bytes);
+    auto res = files::atomic_write(file_path, sram_bytes);
     if (!res) {
         log::error(
-            "[SaveManager] Error writing ERAM to save file: {}", res.error().error_message()
+            "[SaveManager] Error writing SRAM to save file: {}", res.error().error_message()
         );
         return std::unexpected(res.error().error_message());
     }
 
-    log::info("[SaveManager] ERAM saved to file: {}", file_path.string());
+    log::info("[SaveManager] SRAM saved to file: {}", file_path.string());
 
     return {};
 }
 
-auto SaveManager::load_eram(
+auto SaveManager::load_sram(
     std::string_view rom_title, const std::optional<std::filesystem::path>& save_path
 ) -> std::expected<std::vector<uint8_t>, std::string>
 {
-    auto file_path = save_path.value_or(eram_save_path_.value_or(eram_path(rom_title)));
-    log::debug("[SaveManager] Loading ERAM from: {}", file_path.string());
+    auto file_path = save_path.value_or(sram_save_path_.value_or(sram_path(rom_title)));
+    log::debug("[SaveManager] Loading SRAM from: {}", file_path.string());
 
-    auto eram_bytes = files::read_binary(file_path);
-    if (!eram_bytes) {
-        log::error("[SaveManager] Error loading ERAM file: {}", eram_bytes.error().error_message());
-        return std::unexpected(eram_bytes.error().error_message());
+    auto sram_bytes = files::read_binary(file_path);
+    if (!sram_bytes) {
+        log::error("[SaveManager] Error loading SRAM file: {}", sram_bytes.error().error_message());
+        return std::unexpected(sram_bytes.error().error_message());
     }
 
-    if (eram_bytes->size() < 2) {
-        log::error("[SaveManager] ERAM save file too small");
-        return std::unexpected(eram_bytes.error().error_message());
+    if (sram_bytes->size() < 2) {
+        log::error("[SaveManager] SRAM save file too small");
+        return std::unexpected(sram_bytes.error().error_message());
     }
 
     // Create a span view to calculate the checksum and avoid allocation if it fails
-    auto eram_span = std::span(
+    auto sram_span = std::span(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        reinterpret_cast<const uint8_t*>(eram_bytes->data()),
-        eram_bytes->size() - 2
+        reinterpret_cast<const uint8_t*>(sram_bytes->data()),
+        sram_bytes->size() - 2
     );
 
     // Compare checksums
-    uint16_t read_cks = read_checksum(*eram_bytes);
-    uint16_t calc_cks = checksum(eram_span);
+    uint16_t read_cks = read_checksum(*sram_bytes);
+    uint16_t calc_cks = checksum(sram_span);
     if (read_cks != calc_cks) {
         log::error(
-            "[SaveManager] Checksum mismatch for ERAM save file: read {}, calc {}",
+            "[SaveManager] Checksum mismatch for SRAM save file: read {}, calc {}",
             utils::PrettyHex{read_cks}.to_string(),
             utils::PrettyHex{calc_cks}.to_string()
         );
         return {};
     }
 
-    log::info("[SaveManager] ERAM save file loaded from: {}", file_path.string());
+    log::info("[SaveManager] SRAM save file loaded from: {}", file_path.string());
 
-    return std::vector<uint8_t>{eram_span.begin(), eram_span.end()};
+    return std::vector<uint8_t>{sram_span.begin(), sram_span.end()};
 }
 
-std::filesystem::path SaveManager::eram_path(std::string_view rom_title)
+std::filesystem::path SaveManager::sram_path(std::string_view rom_title)
 {
     return files::DataDir / utils::normalize_rom_title(rom_title) / BatteryRamFile;
 }

--- a/src/boyboy/common/save/save_manager.cpp
+++ b/src/boyboy/common/save/save_manager.cpp
@@ -1,0 +1,134 @@
+/**
+ * @file save_manager.cpp
+ * @brief Save Manager for BoyBoy emulator.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "boyboy/common/save/save_manager.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <numeric>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "boyboy/common/files/io.h"
+#include "boyboy/common/files/paths.h"
+#include "boyboy/common/log/logging.h"
+#include "boyboy/common/utils.h"
+
+namespace boyboy::common::save {
+
+constexpr auto BatteryRamFile = "battery.sav";
+
+auto SaveManager::save_eram(
+    std::string_view rom_title,
+    std::span<const uint8_t> data,
+    const std::optional<std::filesystem::path>& save_path
+) -> std::expected<void, std::string>
+{
+    auto file_path = save_path.value_or(eram_path(rom_title));
+    log::debug("[SaveManager] Saving ERAM to: {}", file_path.string());
+
+    if (!std::filesystem::exists(file_path)) {
+        log::debug(
+            "[SaveManager] ERAM save file does not exist, creating new one: {}", file_path.string()
+        );
+    }
+
+    // Create a vector of bytes to append the checksum
+    std::vector<std::byte> eram_bytes{data.size() + 2}; // fit all data + checksum
+    std::ranges::transform(data.begin(), data.end(), eram_bytes.begin(), [](uint8_t b) {
+        return std::byte{b};
+    });
+
+    // Calculate checksum and write to buffer
+    uint16_t cks = checksum(data);
+    write_checksum(eram_bytes, cks);
+
+    auto res = files::write_binary(file_path, eram_bytes);
+    if (!res) {
+        log::error(
+            "[SaveManager] Error writing ERAM to save file: {}", res.error().error_message()
+        );
+        return std::unexpected(res.error().error_message());
+    }
+
+    log::info("[SaveManager] ERAM saved to file: {}", file_path.string());
+
+    return {};
+}
+
+auto SaveManager::load_eram(
+    std::string_view rom_title, const std::optional<std::filesystem::path>& save_path
+) -> std::expected<std::vector<uint8_t>, std::string>
+{
+    auto file_path = save_path.value_or(eram_path(rom_title));
+    log::debug("[SaveManager] Loading ERAM from: {}", file_path.string());
+
+    auto eram_bytes = files::read_binary(file_path);
+    if (!eram_bytes) {
+        log::error("[SaveManager] Error loading ERAM file: {}", eram_bytes.error().error_message());
+        return std::unexpected(eram_bytes.error().error_message());
+    }
+
+    if (eram_bytes->size() < 2) {
+        log::error("[SaveManager] ERAM save file too small");
+        return std::unexpected(eram_bytes.error().error_message());
+    }
+
+    // Create a span view to calculate the checksum and avoid allocation if it fails
+    auto eram_span = std::span(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<const uint8_t*>(eram_bytes->data()),
+        eram_bytes->size() - 2
+    );
+
+    // Compare checksums
+    uint16_t read_cks = read_checksum(*eram_bytes);
+    uint16_t calc_cks = checksum(eram_span);
+    if (read_cks != calc_cks) {
+        log::error(
+            "[SaveManager] Checksum mismatch for ERAM save file: read {}, calc {}",
+            utils::PrettyHex{read_cks}.to_string(),
+            utils::PrettyHex{calc_cks}.to_string()
+        );
+        return {};
+    }
+
+    log::info("[SaveManager] ERAM save file loaded from: {}", file_path.string());
+
+    return std::vector<uint8_t>{eram_span.begin(), eram_span.end()};
+}
+
+std::filesystem::path SaveManager::eram_path(std::string_view rom_title)
+{
+    return files::DataDir / utils::normalize_rom_title(rom_title) / BatteryRamFile;
+}
+
+uint16_t SaveManager::checksum(std::span<const uint8_t> data)
+{
+    uint16_t cks = 0;
+    cks = std::accumulate(data.begin(), data.end(), cks);
+
+    return cks;
+}
+
+[[nodiscard]] uint16_t SaveManager::read_checksum(std::span<const std::byte> buf)
+{
+    std::span<const std::byte> cks_span(buf.end() - 2, buf.end());
+    return utils::to_u16(cks_span[0], cks_span[1]);
+}
+
+void SaveManager::write_checksum(std::span<std::byte> buf, uint16_t cks)
+{
+    std::span<std::byte> cks_span(buf.end() - 2, buf.end());
+    cks_span[0] = std::byte{utils::msb(cks)};
+    cks_span[1] = std::byte{utils::lsb(cks)};
+}
+
+} // namespace boyboy::common::save

--- a/src/boyboy/common/save/save_manager.cpp
+++ b/src/boyboy/common/save/save_manager.cpp
@@ -31,7 +31,7 @@ auto SaveManager::save_eram(
     const std::optional<std::filesystem::path>& save_path
 ) -> std::expected<void, std::string>
 {
-    auto file_path = save_path.value_or(eram_path(rom_title));
+    auto file_path = save_path.value_or(eram_save_path_.value_or(eram_path(rom_title)));
     log::debug("[SaveManager] Saving ERAM to: {}", file_path.string());
 
     if (!std::filesystem::exists(file_path)) {
@@ -67,7 +67,7 @@ auto SaveManager::load_eram(
     std::string_view rom_title, const std::optional<std::filesystem::path>& save_path
 ) -> std::expected<std::vector<uint8_t>, std::string>
 {
-    auto file_path = save_path.value_or(eram_path(rom_title));
+    auto file_path = save_path.value_or(eram_save_path_.value_or(eram_path(rom_title)));
     log::debug("[SaveManager] Loading ERAM from: {}", file_path.string());
 
     auto eram_bytes = files::read_binary(file_path);

--- a/src/boyboy/common/save/save_manager.cpp
+++ b/src/boyboy/common/save/save_manager.cpp
@@ -50,7 +50,7 @@ auto SaveManager::save_eram(
     uint16_t cks = checksum(data);
     write_checksum(eram_bytes, cks);
 
-    auto res = files::write_binary(file_path, eram_bytes);
+    auto res = files::atomic_write(file_path, eram_bytes);
     if (!res) {
         log::error(
             "[SaveManager] Error writing ERAM to save file: {}", res.error().error_message()

--- a/src/boyboy/common/utils.cpp
+++ b/src/boyboy/common/utils.cpp
@@ -7,6 +7,8 @@
 
 #include "boyboy/common/utils.h"
 
+#include <algorithm>
+
 namespace boyboy::common::utils {
 
 /**
@@ -58,6 +60,35 @@ const char* as_char_ptr(const std::byte* ptr) noexcept
     );
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return reinterpret_cast<const char*>(ptr);
+}
+
+std::string normalize_rom_title(std::string_view rom_title)
+{
+    std::string title{rom_title};
+    // To lowercase
+    std::ranges::transform(title, title.begin(), [](unsigned char c) { return std::tolower(c); });
+
+    // Remove apostrophes
+    std::erase(title, '\'');
+
+    // Replace non-alphanumeric with underscore
+    std::ranges::for_each(title, [](char& c) {
+        if (!std::isalnum(static_cast<unsigned char>(c))) {
+            c = '_';
+        }
+    });
+
+    // Collapse multiple underscores into one
+    title.erase(
+        std::ranges::unique(title, [](char a, char b) { return a == '_' && b == '_'; }).begin(),
+        title.end()
+    );
+
+    // Trim leading/trailing underscores
+    title.erase(0, title.find_first_not_of('_'));
+    title.erase(title.find_last_not_of('_') + 1);
+
+    return title;
 }
 
 } // namespace boyboy::common::utils

--- a/src/boyboy/core/cartridge/cartridge.cpp
+++ b/src/boyboy/core/cartridge/cartridge.cpp
@@ -72,7 +72,6 @@ bool Cartridge::is_cart_supported() const
         case CartridgeType::ROMOnly:
         case CartridgeType::MBC1:
         case CartridgeType::MBC1RAM:
-        // TODO: support battery-backed RAM
         case CartridgeType::MBC1RAMBattery:
             return true;
         case CartridgeType::MBC2:
@@ -107,6 +106,10 @@ void Cartridge::load_ram()
 {
     if (mbc_.has_battery() && on_ram_load_cb_) {
         auto ram = on_ram_load_cb_();
+        if (ram.empty()) {
+            log::warn("[Cartridge] SRAM load callback returned empty data, skipping SRAM load");
+            return;
+        }
         mbc_.set_ram(ram);
         mbc_.clear_save();
     }

--- a/src/boyboy/core/cartridge/cartridge.cpp
+++ b/src/boyboy/core/cartridge/cartridge.cpp
@@ -98,7 +98,9 @@ bool Cartridge::is_cart_supported() const
 void Cartridge::tick()
 {
     mbc_.tick();
-    save_ram();
+    if (autosave_enabled_) {
+        save_ram();
+    }
 }
 
 void Cartridge::load_ram()

--- a/src/boyboy/core/cartridge/cartridge.cpp
+++ b/src/boyboy/core/cartridge/cartridge.cpp
@@ -95,6 +95,30 @@ bool Cartridge::is_cart_supported() const
     }
 }
 
+void Cartridge::tick()
+{
+    mbc_.tick();
+    save_ram();
+}
+
+void Cartridge::load_ram()
+{
+    if (mbc_.has_battery() && on_ram_load_cb_) {
+        auto ram = on_ram_load_cb_();
+        mbc_.set_ram(ram);
+        mbc_.clear_save();
+    }
+}
+
+void Cartridge::save_ram()
+{
+    if (mbc_.has_battery() && mbc_.is_save_pending() && on_ram_save_cb_) {
+        if (on_ram_save_cb_(mbc_.get_ram())) {
+            mbc_.clear_save();
+        }
+    }
+}
+
 uint8_t Cartridge::header_checksum(const RomData& rom_data)
 {
     return std::accumulate(

--- a/src/boyboy/core/cartridge/cartridge_loader.cpp
+++ b/src/boyboy/core/cartridge/cartridge_loader.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <memory>
 
 #include "boyboy/common/log/logging.h"
 #include "boyboy/common/utils.h"
@@ -19,19 +20,19 @@ namespace boyboy::core::cartridge {
 
 using namespace boyboy::common;
 
-Cartridge CartridgeLoader::load(std::string_view path)
+std::unique_ptr<Cartridge> CartridgeLoader::load(std::string_view path)
 {
     return load(load_rom_data(path));
 }
 
-Cartridge CartridgeLoader::load(RomData&& rom_data)
+std::unique_ptr<Cartridge> CartridgeLoader::load(RomData&& rom_data)
 {
-    return {std::move(rom_data)};
+    return std::make_unique<Cartridge>(std::move(rom_data));
 }
 
-Cartridge CartridgeLoader::load(const RomData& rom_data)
+std::unique_ptr<Cartridge> CartridgeLoader::load(const RomData& rom_data)
 {
-    return {rom_data};
+    return std::make_unique<Cartridge>(rom_data);
 }
 
 RomData CartridgeLoader::load_rom_data(std::string_view path)

--- a/src/boyboy/core/cartridge/cartridge_loader.cpp
+++ b/src/boyboy/core/cartridge/cartridge_loader.cpp
@@ -9,11 +9,10 @@
 
 #include <filesystem>
 #include <format>
-#include <fstream>
 #include <memory>
 
-#include "boyboy/common/log/logging.h"
-#include "boyboy/common/utils.h"
+#include "boyboy/common/files/errors.h"
+#include "boyboy/common/files/io.h"
 #include "boyboy/core/cartridge/cartridge.h"
 
 namespace boyboy::core::cartridge {
@@ -37,37 +36,16 @@ std::unique_ptr<Cartridge> CartridgeLoader::load(const RomData& rom_data)
 
 RomData CartridgeLoader::load_rom_data(std::string_view path)
 {
-    namespace fs = std::filesystem;
+    std::filesystem::path file_path(path);
 
-    fs::path file_path(path);
-
-    if (!fs::exists(file_path)) {
-        log::debug("Current path: {}", fs::current_path().string());
-        throw std::runtime_error(std::format("ROM File not found: {}", path));
+    auto rom_data = files::read_binary(file_path);
+    if (!rom_data) {
+        throw std::runtime_error(
+            std::format("Error loading ROM data: {}", rom_data.error().error_message())
+        );
     }
 
-    std::uintmax_t file_size = 0;
-    try {
-        file_size = fs::file_size(file_path);
-    }
-    catch (const fs::filesystem_error& e) {
-        throw std::runtime_error(std::format("Failed to get ROM file size: {}", e.what()));
-    }
-
-    std::ifstream rom_file(file_path, std::ios::binary);
-    if (!rom_file.is_open()) {
-        throw std::runtime_error(std::format("Failed to open ROM file: {}", path));
-    }
-
-    RomData rom_data(file_size);
-    rom_file.read(utils::as_char_ptr(rom_data.data()), static_cast<std::streamsize>(file_size));
-
-    if (rom_file.gcount() != static_cast<std::streamsize>(file_size)) {
-        rom_data.clear();
-        throw std::runtime_error("Failed to read entire ROM file");
-    }
-
-    return rom_data;
+    return *rom_data;
 }
 
 } // namespace boyboy::core::cartridge

--- a/src/boyboy/core/cartridge/mbc.cpp
+++ b/src/boyboy/core/cartridge/mbc.cpp
@@ -210,7 +210,7 @@ void Mbc::tick()
     if (has_battery_ && eram_dirty_ && !save_pending_) {
         auto now = BatteryClock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_save_);
-        if (elapsed.count() >= save_period_ms_) {
+        if (elapsed.count() >= save_interval_ms_) {
             save_pending_ = true;
             log::debug("[MBC] Pending ERAM save");
         }

--- a/src/boyboy/core/cartridge/mbc.cpp
+++ b/src/boyboy/core/cartridge/mbc.cpp
@@ -99,8 +99,8 @@ void Mbc::unload_banks()
     if (rom_bank_cnt_ > 1 && addr >= mmu::ROMBank1Start && addr <= mmu::ROMBank1End) {
         return selected_rom_bank().at(addr - mmu::ROMBank1Start);
     }
-    if (ram_enable_ && ram_bank_cnt_ > 0 && addr >= mmu::ERAMStart && addr <= mmu::ERAMEnd) {
-        return selected_ram_bank().at(addr - mmu::ERAMStart);
+    if (ram_enable_ && ram_bank_cnt_ > 0 && addr >= mmu::SRAMStart && addr <= mmu::SRAMEnd) {
+        return selected_ram_bank().at(addr - mmu::SRAMStart);
     }
 
     // return openbus otherwise
@@ -176,10 +176,10 @@ void Mbc::write(uint16_t addr, uint8_t value)
         banking_mode_ = value & 0x01;
         log::trace("Banking mode set to {}", banking_mode_);
     }
-    else if (addr >= mmu::ERAMStart && addr <= mmu::ERAMEnd && ram_bank_cnt_ > 0) {
+    else if (addr >= mmu::SRAMStart && addr <= mmu::SRAMEnd && ram_bank_cnt_ > 0) {
         // write to RAM bank if any
-        selected_ram_bank().at(addr - mmu::ERAMStart) = value;
-        eram_dirty_ = true;
+        selected_ram_bank().at(addr - mmu::SRAMStart) = value;
+        sram_dirty_ = true;
     }
     // else ignore
 }
@@ -207,12 +207,12 @@ void Mbc::set_ram(std::span<const uint8_t> ram)
 
 void Mbc::tick()
 {
-    if (has_battery_ && eram_dirty_ && !save_pending_) {
+    if (has_battery_ && sram_dirty_ && !save_pending_) {
         auto now = BatteryClock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_save_);
         if (elapsed.count() >= save_interval_ms_) {
             save_pending_ = true;
-            log::debug("[MBC] Pending ERAM save");
+            log::debug("[MBC] Pending SRAM save");
         }
     }
 }

--- a/src/boyboy/core/emulator/emulator.cpp
+++ b/src/boyboy/core/emulator/emulator.cpp
@@ -44,11 +44,11 @@ void Emulator::start()
     ppu_.set_dma_start_cb([this](uint8_t value) { mmu_->start_dma(value); });
     display_.set_button_cb([this](io::Button b, bool p) { on_button_event(b, p); });
     cartridge_->set_ram_load_cb([this]() {
-        auto res = save::SaveManager::load_eram(cartridge_->get_header().title);
+        auto res = save::SaveManager::instance().load_eram(cartridge_->get_header().title);
         return (res.has_value()) ? res.value() : std::vector<uint8_t>{};
     });
     cartridge_->set_ram_save_cb([this](auto data) {
-        auto res = save::SaveManager::save_eram(cartridge_->get_header().title, data);
+        auto res = save::SaveManager::instance().save_eram(cartridge_->get_header().title, data);
         return res.has_value();
     });
 

--- a/src/boyboy/core/emulator/emulator.cpp
+++ b/src/boyboy/core/emulator/emulator.cpp
@@ -25,7 +25,7 @@ void Emulator::load(const std::string& path)
     log::info("Loading ROM from {}", path);
 
     cartridge_ = cartridge::CartridgeLoader::load(path);
-    mmu_->map_rom(cartridge_);
+    mmu_->map_rom(*cartridge_);
 }
 
 void Emulator::start()

--- a/src/boyboy/core/emulator/emulator.cpp
+++ b/src/boyboy/core/emulator/emulator.cpp
@@ -44,11 +44,11 @@ void Emulator::start()
     ppu_.set_dma_start_cb([this](uint8_t value) { mmu_->start_dma(value); });
     display_.set_button_cb([this](io::Button b, bool p) { on_button_event(b, p); });
     cartridge_->set_ram_load_cb([this]() {
-        auto res = save::SaveManager::instance().load_eram(cartridge_->get_header().title);
+        auto res = save::SaveManager::instance().load_sram(cartridge_->get_header().title);
         return (res.has_value()) ? res.value() : std::vector<uint8_t>{};
     });
     cartridge_->set_ram_save_cb([this](auto data) {
-        auto res = save::SaveManager::instance().save_eram(cartridge_->get_header().title, data);
+        auto res = save::SaveManager::instance().save_sram(cartridge_->get_header().title, data);
         return res.has_value();
     });
 

--- a/src/boyboy/core/emulator/emulator.cpp
+++ b/src/boyboy/core/emulator/emulator.cpp
@@ -136,8 +136,8 @@ void Emulator::apply_config(const common::config::Config& config)
     display_.set_vsync(config.video.vsync);
 
     // Battery save settings
-    cartridge_->enable_autosave(config.battery.autosave);
-    cartridge_->set_save_interval_ms(config.battery.interval_ms);
+    cartridge_->enable_autosave(config.saves.autosave);
+    cartridge_->set_save_interval_ms(config.saves.save_interval);
 
     // Logging settings
     log::set_level(config.debug.log_level);

--- a/src/boyboy/core/emulator/emulator.cpp
+++ b/src/boyboy/core/emulator/emulator.cpp
@@ -135,6 +135,10 @@ void Emulator::apply_config(const common::config::Config& config)
     display_.set_scale(config.video.scale);
     display_.set_vsync(config.video.vsync);
 
+    // Battery save settings
+    cartridge_->enable_autosave(config.battery.autosave);
+    cartridge_->set_save_interval_ms(config.battery.interval_ms);
+
     // Logging settings
     log::set_level(config.debug.log_level);
 

--- a/src/boyboy/core/mmu/mmu.cpp
+++ b/src/boyboy/core/mmu/mmu.cpp
@@ -48,7 +48,7 @@ void Mmu::map_rom(cartridge::Cartridge& cart)
 {
     auto& rom_bank0 = map(MemoryRegionID::ROMBank0);
     auto& rom_bank1 = map(MemoryRegionID::ROMBank1);
-    auto& eram = map(MemoryRegionID::ERAM);
+    auto& sram = map(MemoryRegionID::SRAM);
 
     auto cart_read = [&cart](uint16_t addr) -> uint8_t {
         return cart.mbc_read(addr);
@@ -65,9 +65,9 @@ void Mmu::map_rom(cartridge::Cartridge& cart)
     rom_bank1.read_handler = cart_read;
     rom_bank1.write_handler = cart_write;
 
-    // Map ERAM (0xA000 - 0xBFFF)
-    eram.read_handler = cart_read;
-    eram.write_handler = cart_write;
+    // Map SRAM (0xA000 - 0xBFFF)
+    sram.read_handler = cart_read;
+    sram.write_handler = cart_write;
 
     rom_loaded_ = true;
 }
@@ -386,15 +386,15 @@ void Mmu::init_memory_map()
             common::utils::PrettyHex(value).to_string()
         );
     };
-    auto unloaded_eram_read = [](uint16_t addr) -> uint8_t {
+    auto unloaded_sram_read = [](uint16_t addr) -> uint8_t {
         log::warn(
-            "Read from ERAM before ROM loaded at {}", common::utils::PrettyHex(addr).to_string()
+            "Read from SRAM before ROM loaded at {}", common::utils::PrettyHex(addr).to_string()
         );
         return OpenBusValue;
     };
-    auto unloaded_eram_write = [](uint16_t addr, uint8_t value) {
+    auto unloaded_sram_write = [](uint16_t addr, uint8_t value) {
         log::warn(
-            "Write to ERAM before ROM loaded at {}: {}",
+            "Write to SRAM before ROM loaded at {}: {}",
             common::utils::PrettyHex(addr).to_string(),
             common::utils::PrettyHex(value).to_string()
         );
@@ -422,13 +422,13 @@ void Mmu::init_memory_map()
         .end = VRAMEnd,
         .data = vram_,
     };
-    map(MemoryRegionID::ERAM) = {
-        .id = MemoryRegionID::ERAM,
-        .start = ERAMStart,
-        .end = ERAMEnd,
+    map(MemoryRegionID::SRAM) = {
+        .id = MemoryRegionID::SRAM,
+        .start = SRAMStart,
+        .end = SRAMEnd,
         .data = {},
-        .read_handler = unloaded_eram_read,
-        .write_handler = unloaded_eram_write,
+        .read_handler = unloaded_sram_read,
+        .write_handler = unloaded_sram_write,
     };
     map(MemoryRegionID::WRAM0) = {
         .id = MemoryRegionID::WRAM0,

--- a/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
+++ b/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
@@ -10,6 +10,7 @@
 #include <CLI/CLI.hpp>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "boyboy/app/app.h"
 #include "boyboy/app/commands/config_command.h"
@@ -25,13 +26,24 @@ inline static constexpr std::string_view RunCommandName = "run";
 inline static constexpr std::string_view InfoCommandName = "info";
 inline static constexpr std::string_view ConfigCommandName = "config";
 
+inline static const std::string GlobalFooter = std::format(
+    "For more information and bug reports, visit <https://github.com/sebdevnull/boyboy>\n\n{}",
+    version::LicenseLong
+);
+
+namespace {
+std::string make_footer(std::string&& footer)
+{
+    return std::move(footer) + "\n" + GlobalFooter;
+}
+} // namespace
+
 CLI11Adapter::CLI11Adapter(app::App& app, app::commands::CommandContext& context)
     : app_(app), context_(context)
 {
     app_parser_.name("boyboy");
     app_parser_.description("BoyBoy - A Game Boy emulator");
     app_parser_.set_help_flag("-h,--help", "Print help message and exit");
-    app_parser_.set_help_all_flag("--help-all", "Print all help messages and exit");
     app_parser_.set_version_flag("-v,--version", app::App::version());
     app_parser_.add_flag_callback(
         "--build-info",
@@ -42,10 +54,7 @@ CLI11Adapter::CLI11Adapter(app::App& app, app::commands::CommandContext& context
         "Display detailed build information and exit"
     );
 
-    app_parser_.footer(std::format(
-        "For more information and bug reports, visit <https://github.com/sebdevnull/boyboy>\n\n{}",
-        version::LicenseLong
-    ));
+    app_parser_.footer(GlobalFooter);
 }
 
 int CLI11Adapter::run(std::span<std::string_view> args)
@@ -102,35 +111,29 @@ void CLI11Adapter::register_run(app::commands::RunCommand& command)
     auto* cmd = app_parser_.add_subcommand(
         std::string(command.name()), std::string(command.description())
     );
-    cmd->footer(R"(
+    cmd->footer(make_footer(R"(
         Examples:
           boyboy run path/to/rom.gb
           boyboy run path/to/rom.gb --config path/to/config.toml
-          boyboy run path/to/rom.gb --scale 2 --speed 2 --no-vsync
+          boyboy run path/to/rom.gb --scale 2 --speed 2 --vsync off
         
         Notes:
           Any options provided here will override those in the configuration file.
-    )");
+    )"));
 
-    cmd->add_option("rom", context_.rom_path, "Path to the ROM file")
-        ->option_text("<path>")
-        ->required();
+    cmd->add_option("<rom>", context_.rom_path, "Path to the ROM file")->type_name("")->required();
     cmd->add_option("-c,--config", context_.config_path, "Path to the configuration file")
-        ->option_text("<path>");
-    cmd->add_option("--scale", options_.scale, "Scaling factor for the display (x1, x2, x3, etc.)")
-        ->option_text("<scale>");
-    cmd->add_option(
-           "--speed", options_.speed, "Emulation speed (0 = uncapped, 1 = normal, 2 = double, etc.)"
-    )
-        ->option_text("<speed>");
-    cmd->add_flag(
-        "--vsync,!--no-vsync", options_.vsync, "Enable or disable vertical synchronization"
-    );
+        ->type_name("<file>");
+    cmd->add_option("--scale", options_.scale, "Display scaling factor")->type_name("<factor>");
+    cmd->add_option("--speed", options_.speed, "Emulation speed multiplier (0 = uncapped)")
+        ->type_name("<mult>");
+    cmd->add_option("--vsync", options_.vsync, "Enable or disable vertical synchronization")
+        ->type_name("<bool>");
     cmd->add_option(
            "--log-level",
            context_.log_level,
            std::format(
-               "Set the logging level ({})",
+               "Logging level: {}",
                common::config::ConfigLimits::Debug::LogLevelOptions.option_list()
            )
     )
@@ -138,15 +141,14 @@ void CLI11Adapter::register_run(app::commands::RunCommand& command)
         ->check(CLI::IsMember(common::config::ConfigLimits::Debug::LogLevels));
 
     // Battery save options
-    cmd->add_option("--bat-path", options_.save_path, "Battery save path for this ROM")
-        ->option_text("<path>");
-    cmd->add_flag(
-        "--bat-autosave,!--no-bat-autosave", options_.autosave, "Enable or disable battery autosave"
-    );
+    cmd->add_option("--save-file", options_.save_path, "Battery save file for this ROM")
+        ->type_name("<file>");
+    cmd->add_option("--autosave", options_.autosave, "Enable or disable battery autosave")
+        ->type_name("<bool>");
     cmd->add_option(
-           "--bat-interval", options_.save_interval_ms, "Battery autosave interval in milliseconds"
+           "--save-interval", options_.save_interval_ms, "Battery autosave interval in milliseconds"
     )
-        ->option_text("<ms>");
+        ->type_name("<t>");
 
     cmd->callback([this, &command]() {
         command.set_scale(options_.scale);
@@ -164,14 +166,12 @@ void CLI11Adapter::register_info(app::commands::InfoCommand& command)
     auto* cmd = app_parser_.add_subcommand(
         std::string(command.name()), std::string(command.description())
     );
-    cmd->footer(R"(
+    cmd->footer(make_footer(R"(
         Examples:
           boyboy info path/to/rom.gb
-    )");
+    )"));
 
-    cmd->add_option("rom", context_.rom_path, "Path to the ROM file")
-        ->option_text("<path>")
-        ->required();
+    cmd->add_option("<rom>", context_.rom_path, "Path to the ROM file")->type_name("")->required();
 
     cmd->callback([this, &command]() { command.execute(app_, context_); });
 }
@@ -182,32 +182,28 @@ void CLI11Adapter::register_config(app::commands::ConfigCommand& command)
         std::string(command.name()), std::string(command.description())
     );
     cli_config->add_option("-c,--config", context_.config_path, "Path to the configuration file")
-        ->option_text("<path>");
+        ->type_name("<file>");
     cli_config->require_subcommand(1);
 
     // Get
     auto* get_sub = cli_config->add_subcommand("get", "Get a configuration value");
-    get_sub->add_option("key", options_.cfg_key, "Configuration key")
-        ->option_text("<key>")
-        ->required();
+    get_sub->add_option("<key>", options_.cfg_key, "Configuration key")->type_name("")->required();
     get_sub->callback([this, &command]() {
         command.set_subcommand(app::commands::ConfigCommand::SubCommand::Get);
         command.set_key(options_.cfg_key);
         command.execute(app_, context_);
     });
-    get_sub->footer(R"(
+    get_sub->footer(make_footer(R"(
         Examples:
           boyboy config get emulator.speed
           boyboy config -c path/to/config.toml get video.vsync
-    )");
+    )"));
 
     // Set
     auto* set_sub = cli_config->add_subcommand("set", "Set a configuration value");
-    set_sub->add_option("key", options_.cfg_key, "Configuration key")
-        ->option_text("<key>")
-        ->required();
-    set_sub->add_option("value", options_.cfg_value, "Configuration value")
-        ->option_text("<value>")
+    set_sub->add_option("<key>", options_.cfg_key, "Configuration key")->type_name("")->required();
+    set_sub->add_option("<value>", options_.cfg_value, "Configuration value")
+        ->type_name("")
         ->required();
     set_sub->callback([this, &command]() {
         command.set_subcommand(app::commands::ConfigCommand::SubCommand::Set);
@@ -215,11 +211,11 @@ void CLI11Adapter::register_config(app::commands::ConfigCommand& command)
         command.set_value(options_.cfg_value);
         command.execute(app_, context_);
     });
-    set_sub->footer(R"(
+    set_sub->footer(make_footer(R"(
         Examples:
           boyboy config set emulator.speed 2
           boyboy config -c path/to/config.toml set video.vsync true
-    )");
+    )"));
 
     // List
     auto* list_sub = cli_config->add_subcommand("list", "List configuration values");
@@ -227,11 +223,11 @@ void CLI11Adapter::register_config(app::commands::ConfigCommand& command)
         command.set_subcommand(app::commands::ConfigCommand::SubCommand::List);
         command.execute(app_, context_);
     });
-    list_sub->footer(R"(
+    list_sub->footer(make_footer(R"(
         Examples:
           boyboy config list
           boyboy config -c path/to/config.toml list
-    )");
+    )"));
 
     // Reset
     auto* reset_sub = cli_config->add_subcommand("reset", "Reset configuration to default");
@@ -239,11 +235,11 @@ void CLI11Adapter::register_config(app::commands::ConfigCommand& command)
         command.set_subcommand(app::commands::ConfigCommand::SubCommand::Reset);
         command.execute(app_, context_);
     });
-    reset_sub->footer(R"(
+    reset_sub->footer(make_footer(R"(
         Examples:
           boyboy config reset
           boyboy config -c path/to/config.toml reset
-    )");
+    )"));
 }
 
 } // namespace boyboy::frontend::cli

--- a/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
+++ b/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
@@ -126,7 +126,6 @@ void CLI11Adapter::register_run(app::commands::RunCommand& command)
     cmd->add_flag(
         "--vsync,!--no-vsync", options_.vsync, "Enable or disable vertical synchronization"
     );
-
     cmd->add_option(
            "--log-level",
            context_.log_level,
@@ -138,10 +137,24 @@ void CLI11Adapter::register_run(app::commands::RunCommand& command)
         ->option_text("LEVEL")
         ->check(CLI::IsMember(common::config::ConfigLimits::Debug::LogLevels));
 
+    // Battery save options
+    cmd->add_option("--bat-path", options_.save_path, "Battery save path for this ROM")
+        ->option_text("PATH");
+    cmd->add_flag(
+        "--bat-autosave,!--no-bat-autosave", options_.autosave, "Enable or disable battery autosave"
+    );
+    cmd->add_option(
+           "--bat-interval", options_.save_interval_ms, "Battery autosave interval in milliseconds"
+    )
+        ->option_text("INTERVAL_MS");
+
     cmd->callback([this, &command]() {
         command.set_scale(options_.scale);
         command.set_speed(options_.speed);
         command.set_vsync(options_.vsync);
+        command.set_save_path(options_.save_path);
+        command.set_autosave(options_.autosave);
+        command.set_save_interval_ms(options_.save_interval_ms);
         command.execute(app_, context_);
     });
 }

--- a/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
+++ b/src/boyboy/frontend/cli/adapters/cli11_adapter.cpp
@@ -113,16 +113,16 @@ void CLI11Adapter::register_run(app::commands::RunCommand& command)
     )");
 
     cmd->add_option("rom", context_.rom_path, "Path to the ROM file")
-        ->option_text("ROM_PATH")
+        ->option_text("<path>")
         ->required();
     cmd->add_option("-c,--config", context_.config_path, "Path to the configuration file")
-        ->option_text("PATH");
+        ->option_text("<path>");
     cmd->add_option("--scale", options_.scale, "Scaling factor for the display (x1, x2, x3, etc.)")
-        ->option_text("SCALE");
+        ->option_text("<scale>");
     cmd->add_option(
            "--speed", options_.speed, "Emulation speed (0 = uncapped, 1 = normal, 2 = double, etc.)"
     )
-        ->option_text("SPEED");
+        ->option_text("<speed>");
     cmd->add_flag(
         "--vsync,!--no-vsync", options_.vsync, "Enable or disable vertical synchronization"
     );
@@ -134,19 +134,19 @@ void CLI11Adapter::register_run(app::commands::RunCommand& command)
                common::config::ConfigLimits::Debug::LogLevelOptions.option_list()
            )
     )
-        ->option_text("LEVEL")
+        ->option_text("<level>")
         ->check(CLI::IsMember(common::config::ConfigLimits::Debug::LogLevels));
 
     // Battery save options
     cmd->add_option("--bat-path", options_.save_path, "Battery save path for this ROM")
-        ->option_text("PATH");
+        ->option_text("<path>");
     cmd->add_flag(
         "--bat-autosave,!--no-bat-autosave", options_.autosave, "Enable or disable battery autosave"
     );
     cmd->add_option(
            "--bat-interval", options_.save_interval_ms, "Battery autosave interval in milliseconds"
     )
-        ->option_text("INTERVAL_MS");
+        ->option_text("<ms>");
 
     cmd->callback([this, &command]() {
         command.set_scale(options_.scale);
@@ -170,7 +170,7 @@ void CLI11Adapter::register_info(app::commands::InfoCommand& command)
     )");
 
     cmd->add_option("rom", context_.rom_path, "Path to the ROM file")
-        ->option_text("ROM_PATH")
+        ->option_text("<path>")
         ->required();
 
     cmd->callback([this, &command]() { command.execute(app_, context_); });
@@ -182,12 +182,14 @@ void CLI11Adapter::register_config(app::commands::ConfigCommand& command)
         std::string(command.name()), std::string(command.description())
     );
     cli_config->add_option("-c,--config", context_.config_path, "Path to the configuration file")
-        ->option_text("PATH");
+        ->option_text("<path>");
     cli_config->require_subcommand(1);
 
     // Get
     auto* get_sub = cli_config->add_subcommand("get", "Get a configuration value");
-    get_sub->add_option("key", options_.cfg_key, "Configuration key")->required();
+    get_sub->add_option("key", options_.cfg_key, "Configuration key")
+        ->option_text("<key>")
+        ->required();
     get_sub->callback([this, &command]() {
         command.set_subcommand(app::commands::ConfigCommand::SubCommand::Get);
         command.set_key(options_.cfg_key);
@@ -201,8 +203,12 @@ void CLI11Adapter::register_config(app::commands::ConfigCommand& command)
 
     // Set
     auto* set_sub = cli_config->add_subcommand("set", "Set a configuration value");
-    set_sub->add_option("key", options_.cfg_key, "Configuration key")->required();
-    set_sub->add_option("value", options_.cfg_value, "Configuration value")->required();
+    set_sub->add_option("key", options_.cfg_key, "Configuration key")
+        ->option_text("<key>")
+        ->required();
+    set_sub->add_option("value", options_.cfg_value, "Configuration value")
+        ->option_text("<value>")
+        ->required();
     set_sub->callback([this, &command]() {
         command.set_subcommand(app::commands::ConfigCommand::SubCommand::Set);
         command.set_key(options_.cfg_key);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set_target_properties(gmock_main PROPERTIES CXX_CLANG_TIDY "")
 set(TEST_SOURCES
     test_main.cpp
     helpers/rom_fixtures.cpp
+    helpers/file_fixtures.cpp
     cartridge/test_cartridge.cpp
     cartridge/test_romonly.cpp
     cartridge/test_mbc.cpp
@@ -61,6 +62,7 @@ set(TEST_SOURCES
     cpu/instructions/instructions_16bit.cpp
     cpu/test_roms.cpp
     config/test_config.cpp
+    files/test_utils.cpp
 )
 
 # --- Options ---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TEST_SOURCES
     cpu/test_roms.cpp
     config/test_config.cpp
     files/test_utils.cpp
+    files/test_io.cpp
 )
 
 # --- Options ---

--- a/tests/cartridge/test_cartridge.cpp
+++ b/tests/cartridge/test_cartridge.cpp
@@ -28,20 +28,20 @@ class CartridgeTest : public ROMTest {};
 TEST_F(CartridgeTest, LoadValidRom)
 {
     EXPECT_NO_THROW(load(ValidROM));
-    EXPECT_GT(cart.get_rom_data().size(), 0);
-    EXPECT_TRUE(cart.is_loaded());
+    EXPECT_GT(cart->get_rom_data().size(), 0);
+    EXPECT_TRUE(cart->is_loaded());
 }
 
 TEST_F(CartridgeTest, LoadInvalidRom)
 {
     EXPECT_THROW(load(InvalidROM), std::runtime_error);
-    EXPECT_FALSE(cart.is_loaded());
+    EXPECT_FALSE(cart->is_loaded());
 }
 
 TEST_F(CartridgeTest, HeaderParsing)
 {
     load(ValidROM);
-    const auto& header = cart.get_header();
+    const auto& header = cart->get_header();
 
     EXPECT_EQ(header.title, "LIFE");
     EXPECT_EQ(header.cartridge_type, CartridgeType::ROMOnly);
@@ -52,8 +52,8 @@ TEST_F(CartridgeTest, HeaderParsing)
 TEST_F(CartridgeTest, UnloadRom)
 {
     load(ValidROM);
-    EXPECT_GT(cart.get_rom_data().size(), 0);
-    cart.unload_rom();
-    EXPECT_EQ(cart.get_rom_data().size(), 0);
-    EXPECT_FALSE(cart.is_loaded());
+    EXPECT_GT(cart->get_rom_data().size(), 0);
+    cart->unload_rom();
+    EXPECT_EQ(cart->get_rom_data().size(), 0);
+    EXPECT_FALSE(cart->is_loaded());
 }

--- a/tests/cartridge/test_mbc.cpp
+++ b/tests/cartridge/test_mbc.cpp
@@ -23,8 +23,8 @@ using boyboy::common::utils::PrettyHex;
 using boyboy::core::cartridge::CartridgeType;
 using boyboy::core::cartridge::mbc::Mbc;
 using boyboy::core::cartridge::mbc::MbcType;
-using boyboy::core::mmu::ERAMStart;
 using boyboy::core::mmu::ROMBank1Start;
+using boyboy::core::mmu::SRAMStart;
 
 TEST_P(MBCParamTest, InitialState)
 {
@@ -213,7 +213,7 @@ TEST_P(MBCParamTest, RamBankSelection)
     EXPECT_TRUE(mbc.is_ram_enabled()) << "RAM should be enabled for RAM bank read/write test";
     for (uint8_t bank = 0; bank < p.ram_banks; bank++) {
         cart->mbc_write(Mbc::RAMBankNumberStart, bank);
-        uint16_t addr = ERAMStart;
+        uint16_t addr = SRAMStart;
         for (uint8_t val = 0; val < 0x10; val++) {
             cart->mbc_write(addr + val, val + (bank * 0x10)); // Distinguish banks by offset
             uint8_t read_val = cart->mbc_read(addr + val);

--- a/tests/cartridge/test_romonly.cpp
+++ b/tests/cartridge/test_romonly.cpp
@@ -14,11 +14,11 @@
 #include "boyboy/core/mmu/constants.h"
 
 using boyboy::common::utils::PrettyHex;
-using boyboy::core::mmu::ERAMStart;
 using boyboy::core::mmu::ROMBank0End;
 using boyboy::core::mmu::ROMBank0Start;
 using boyboy::core::mmu::ROMBank1End;
 using boyboy::core::mmu::ROMBank1Start;
+using boyboy::core::mmu::SRAMStart;
 
 // Helpers
 #include "helpers/rom_fixtures.h"
@@ -91,7 +91,7 @@ TEST_F(RomOnlyTest, RomBankWriteIgnored)
 TEST_F(RomOnlyTest, RamAccessIgnored)
 {
     // Attempt to read from external RAM (should return 0xFF)
-    uint16_t addr = ERAMStart;
+    uint16_t addr = SRAMStart;
     uint8_t val   = cart->mbc_read(addr);
     EXPECT_EQ(val, 0xFF) << "Value read from external RAM at address " << PrettyHex(addr)
                          << " should be 0xFF for ROM-only cartridge";

--- a/tests/cartridge/test_romonly.cpp
+++ b/tests/cartridge/test_romonly.cpp
@@ -32,9 +32,7 @@ protected:
         rom_data = make_fake_rom(
             boyboy::core::cartridge::CartridgeType::ROMOnly, 2, 0, "ROM_ONLY_TEST"
         );
-        cart = std::make_unique<boyboy::core::cartridge::Cartridge>(
-            boyboy::core::cartridge::CartridgeLoader::load(rom_data)
-        );
+        cart = boyboy::core::cartridge::CartridgeLoader::load(rom_data);
     }
 };
 

--- a/tests/config/test_config.cpp
+++ b/tests/config/test_config.cpp
@@ -31,10 +31,12 @@ protected:
 
 TEST_F(ConfigTest, DefaultConfig)
 {
-    EXPECT_EQ(config.emulator.speed, 1);
-    EXPECT_EQ(config.video.scale, 4);
+    EXPECT_EQ(config.emulator.speed, ConfigLimits::Emulator::SpeedRange.default_value);
+    EXPECT_EQ(config.video.scale, ConfigLimits::Video::ScaleRange.default_value);
     EXPECT_TRUE(config.video.vsync);
-    EXPECT_EQ(config.debug.log_level, "info");
+    EXPECT_TRUE(config.saves.autosave);
+    EXPECT_EQ(config.saves.save_interval, ConfigLimits::Saves::SaveInterval.default_value);
+    EXPECT_EQ(config.debug.log_level, ConfigLimits::Debug::LogLevelOptions.default_value);
 }
 
 TEST_F(ConfigTest, ValidateConfig)

--- a/tests/files/test_io.cpp
+++ b/tests/files/test_io.cpp
@@ -1,0 +1,202 @@
+/**
+ * @file test_io.cpp
+ * @brief Unit test for file I/O operations
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <ios>
+#include <string>
+
+#include "helpers/file_fixtures.h"
+
+// boyboy
+#include "boyboy/common/files/errors.h"
+#include "boyboy/common/files/io.h"
+
+using boyboy::common::files::FileError;
+using boyboy::common::files::input_stream;
+using boyboy::common::files::output_stream;
+using boyboy::common::files::read_binary;
+using boyboy::common::files::read_text;
+using boyboy::common::files::write_binary;
+using boyboy::common::files::write_text;
+
+class FileIoTest : public FileTest {
+protected:
+    inline static const std::string SampleText = "This is a test";
+    static constexpr auto SampleBinary         = std::to_array<std::byte>({
+        std::byte{0x00},
+        std::byte{0x01},
+        std::byte{0x02},
+        std::byte{0x03},
+        std::byte{0x04},
+        std::byte{0x05},
+        std::byte{0x06},
+        std::byte{0x07},
+        std::byte{0x08},
+        std::byte{0x09},
+    });
+};
+
+TEST_F(FileIoTest, InputStream)
+{
+    {
+        // Existent file should open correctly
+        auto stream = input_stream(ExistentFile);
+        EXPECT_TRUE(stream.has_value());
+        EXPECT_TRUE(stream->is_open());
+    }
+    {
+        // Non existent file should give error
+        auto stream = input_stream(NonExistentFile);
+        EXPECT_FALSE(stream.has_value());
+        EXPECT_EQ(stream.error().type, FileError::Type::NotFound);
+    }
+    {
+        // Dir should give error
+        auto stream = input_stream(ExistentDir);
+        EXPECT_FALSE(stream.has_value());
+        EXPECT_EQ(stream.error().type, FileError::Type::IsDirectory);
+    }
+}
+
+TEST_F(FileIoTest, OutputStream)
+{
+    {
+        // Existent file should open correctly
+        auto stream = output_stream(ExistentFile);
+        EXPECT_TRUE(stream.has_value());
+        EXPECT_TRUE(stream->is_open());
+    }
+    {
+        // Non existent file should also open correctly and create parent dirs
+        auto parent_dir = NonExistentFile.parent_path();
+        EXPECT_FALSE(std::filesystem::exists(parent_dir));
+
+        auto stream = output_stream(NonExistentFile);
+        EXPECT_TRUE(stream.has_value());
+        EXPECT_TRUE(stream->is_open());
+        EXPECT_TRUE(std::filesystem::exists(parent_dir));
+
+        stream->close();
+        EXPECT_TRUE(std::filesystem::exists(NonExistentFile));
+
+        // Cleanup
+        rm(parent_dir, true);
+    }
+    {
+        // Dir should give error
+        auto stream = output_stream(ExistentDir);
+        EXPECT_FALSE(stream.has_value());
+        EXPECT_EQ(stream.error().type, FileError::Type::IsDirectory);
+    }
+}
+
+TEST_F(FileIoTest, ReadText)
+{
+    {
+        // Read should work with existing text file
+        auto file_path = ExistentFile;
+        {
+            // Create sample file for testing
+            auto file = output_stream(file_path, std::ios::trunc);
+            EXPECT_TRUE(file.has_value());
+
+            file->write(SampleText.data(), static_cast<std::streamsize>(SampleText.size()));
+        }
+
+        auto read_content = read_text(file_path);
+        EXPECT_TRUE(read_content.has_value());
+        EXPECT_EQ(*read_content, SampleText);
+    }
+}
+
+TEST_F(FileIoTest, WriteText)
+{
+    {
+        // Write should work with existing text file
+        auto file_path = ExistentFile;
+        {
+            auto res = write_text(file_path, SampleText);
+            EXPECT_TRUE(res.has_value());
+        }
+
+        // Read back the file content
+        auto read_content = read_text(file_path);
+        EXPECT_TRUE(read_content.has_value());
+        EXPECT_EQ(*read_content, SampleText);
+    }
+    {
+        // Write should also work with non existing file
+        auto file_path = NonExistentFile;
+        {
+            auto res = write_text(file_path, SampleText);
+            EXPECT_TRUE(res.has_value());
+        }
+
+        // Read back the file content
+        auto read_content = read_text(file_path);
+        EXPECT_TRUE(read_content.has_value());
+        EXPECT_EQ(*read_content, SampleText);
+    }
+}
+
+TEST_F(FileIoTest, ReadBinary)
+{
+    {
+        // Read should work with existing text file
+        auto file_path = ExistentFile;
+        {
+            // Create sample file for testing
+            auto file = output_stream(file_path, std::ios::trunc | std::ios::binary);
+            EXPECT_TRUE(file.has_value());
+
+            file->write(
+                reinterpret_cast<const char*>(SampleBinary.data()), // NOLINT
+                static_cast<std::streamsize>(SampleBinary.size())
+            );
+        }
+
+        auto read_bin = read_binary(file_path);
+        EXPECT_TRUE(read_bin.has_value());
+        EXPECT_EQ(read_bin->size(), SampleBinary.size());
+        EXPECT_TRUE(std::ranges::equal(*read_bin, SampleBinary));
+    }
+}
+
+TEST_F(FileIoTest, WriteBinary)
+{
+    {
+        // Write should work with existing binary file
+        auto file_path = ExistentFile;
+        {
+            auto res = write_binary(file_path, SampleBinary);
+            EXPECT_TRUE(res.has_value());
+        }
+
+        // Read back the file content
+        auto read_bin = read_binary(file_path);
+        EXPECT_TRUE(read_bin.has_value());
+        EXPECT_TRUE(std::ranges::equal(*read_bin, SampleBinary));
+    }
+    {
+        // Write should also work with non existing file
+        auto file_path = NonExistentFile;
+        {
+            auto res = write_binary(file_path, SampleBinary);
+            EXPECT_TRUE(res.has_value());
+        }
+
+        // Read back the file content
+        auto read_bin = read_binary(file_path);
+        EXPECT_TRUE(read_bin.has_value());
+        EXPECT_TRUE(std::ranges::equal(*read_bin, SampleBinary));
+    }
+}

--- a/tests/files/test_io.cpp
+++ b/tests/files/test_io.cpp
@@ -20,6 +20,7 @@
 #include "boyboy/common/files/errors.h"
 #include "boyboy/common/files/io.h"
 
+using boyboy::common::files::atomic_write;
 using boyboy::common::files::FileError;
 using boyboy::common::files::input_stream;
 using boyboy::common::files::output_stream;
@@ -191,6 +192,36 @@ TEST_F(FileIoTest, WriteBinary)
         auto file_path = NonExistentFile;
         {
             auto res = write_binary(file_path, SampleBinary);
+            EXPECT_TRUE(res.has_value());
+        }
+
+        // Read back the file content
+        auto read_bin = read_binary(file_path);
+        EXPECT_TRUE(read_bin.has_value());
+        EXPECT_TRUE(std::ranges::equal(*read_bin, SampleBinary));
+    }
+}
+
+TEST_F(FileIoTest, AtomicWrite)
+{
+    {
+        // Atomic write should work with text files
+        auto file_path = ExistentFile;
+        {
+            auto res = atomic_write(file_path, SampleText);
+            EXPECT_TRUE(res.has_value());
+        }
+
+        // Read back the file content
+        auto read_content = read_text(file_path);
+        EXPECT_TRUE(read_content.has_value());
+        EXPECT_EQ(*read_content, SampleText);
+    }
+    {
+        // Atomic write should work with binary files
+        auto file_path = ExistentFile;
+        {
+            auto res = atomic_write(file_path, SampleBinary);
             EXPECT_TRUE(res.has_value());
         }
 

--- a/tests/files/test_utils.cpp
+++ b/tests/files/test_utils.cpp
@@ -1,0 +1,291 @@
+/**
+ * @file test_utils.cpp
+ * @brief Unit tests for file utils.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <filesystem>
+
+#include "helpers/file_fixtures.h"
+
+// boyboy
+#include "boyboy/common/files/errors.h"
+#include "boyboy/common/files/utils.h"
+
+using boyboy::common::files::ensure_parent_dir;
+using boyboy::common::files::ensure_readable;
+using boyboy::common::files::ensure_writable;
+using boyboy::common::files::FileError;
+using boyboy::common::files::stream_size;
+using boyboy::common::files::validate_file;
+using boyboy::common::files::validate_mode;
+using boyboy::common::files::validate_path;
+using boyboy::common::files::validate_permissions;
+
+class FileUtilsTest : public FileTest {};
+
+TEST_F(FileUtilsTest, ValidateFile)
+{
+    {
+        // Existent dir should return error
+        auto res = validate_file(ExistentDir);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::IsDirectory);
+    }
+    {
+        // Existent file should NOT return error
+        auto res = validate_file(ExistentFile);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Non existent dir should NOT return error
+        auto res = validate_file(NonExistentDir);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Non existent file should NOT return error
+        auto res = validate_file(NonExistentFile);
+        EXPECT_TRUE(res.has_value());
+    }
+}
+
+TEST_F(FileUtilsTest, ValidatePath)
+{
+    {
+        // Existent dir should return error
+        auto res = validate_path(ExistentDir);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::IsDirectory);
+    }
+    {
+        // Existent file should NOT return error
+        auto res = validate_path(ExistentFile);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Non existent dir should return error
+        auto res = validate_path(NonExistentDir);
+        EXPECT_EQ(res.error().type, FileError::Type::NotFound);
+    }
+    {
+        // Non existent file should return error
+        auto res = validate_path(NonExistentFile);
+        EXPECT_EQ(res.error().type, FileError::Type::NotFound);
+    }
+}
+
+TEST_F(FileUtilsTest, ValidateMode)
+{
+    // Arbitrary mode
+    auto mode = std::ios::out | std::ios::binary;
+    {
+        // Same mode should NOT return error
+        auto same_mode = mode;
+
+        auto res = validate_mode(mode, same_mode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Opposite mode should return error
+        auto opposite_mode = ~mode;
+
+        auto res = validate_mode(mode, opposite_mode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::BadMode);
+    }
+    {
+        // Matching mode should NOT return error
+        auto expected_mode = std::ios::out;
+
+        auto res = validate_mode(mode, expected_mode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Only one matching mode should return error
+        auto expected_mode = std::ios::out | std::ios::trunc;
+
+        auto res = validate_mode(mode, expected_mode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::BadMode);
+    }
+}
+
+TEST_F(FileUtilsTest, ValidatePermissions)
+{
+    {
+        // Owned dir should NOT return read permission error
+        auto res = validate_permissions(ExistentDir, InMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Owned dir should NOT return write permission error
+        auto res = validate_permissions(ExistentDir, OutMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Owned file should NOT return read permission error
+        auto res = validate_permissions(ExistentFile, InMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Owned file should NOT return write permission error
+        auto res = validate_permissions(ExistentFile, OutMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Non existent dir should NOT return error
+        auto res = validate_permissions(ExistentDir, InMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Non existent file should NOT return error
+        auto res = validate_permissions(ExistentDir, InMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Not owned dir should return error
+        std::filesystem::path dir("/usr/bin");
+        auto res = validate_permissions(dir, OutMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::PermissionDenied);
+    }
+    {
+        // Not owned file should return read error
+        std::filesystem::path dir("/etc/shadow");
+        auto res = validate_permissions(dir, InMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::PermissionDenied);
+    }
+    {
+        // Not owned file should return write error
+        std::filesystem::path dir("/bin/bash");
+        auto res = validate_permissions(dir, OutMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::PermissionDenied);
+    }
+}
+
+TEST_F(FileUtilsTest, EnsureParentDir)
+{
+    {
+        // Non existent parent dir should be created
+        auto parent_dir = NonExistentFile.parent_path();
+        EXPECT_FALSE(std::filesystem::exists(parent_dir));
+
+        auto res = ensure_parent_dir(NonExistentFile);
+        EXPECT_TRUE(res.has_value());
+        EXPECT_TRUE(std::filesystem::exists(parent_dir));
+
+        // Cleanup
+        rmdir(parent_dir);
+    }
+    {
+        // Existent parent dir should do nothing
+        auto parent_dir = ExistentFile.parent_path();
+        EXPECT_TRUE(std::filesystem::exists(parent_dir));
+
+        auto res = ensure_parent_dir(ExistentFile);
+        EXPECT_TRUE(res.has_value());
+        EXPECT_TRUE(std::filesystem::exists(parent_dir));
+    }
+    {
+        // Non existent parent dirs should be created recursively
+        auto long_path  = NonExistentDir / "a" / "b" / "file.txt";
+        auto parent_dir = long_path.parent_path();
+        EXPECT_FALSE(std::filesystem::exists(parent_dir));
+
+        auto res = ensure_parent_dir(long_path);
+        EXPECT_TRUE(res.has_value());
+        EXPECT_TRUE(std::filesystem::exists(parent_dir));
+
+        // Cleanup
+        rm(NonExistentDir, true);
+    }
+}
+
+TEST_F(FileUtilsTest, EnsureReadable)
+{
+    {
+        // Existent file should be readable
+        auto res = ensure_readable(ExistentFile, InMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Non existent file should NOT be readable
+        auto res = ensure_readable(NonExistentFile, InMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::NotFound);
+    }
+    {
+        // Existent file with bad mode should NOT be readable
+        auto res = ensure_readable(ExistentFile, OutMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::BadMode);
+    }
+    {
+        // Existent dir should NOT be readable
+        auto res = ensure_readable(ExistentDir, InMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::IsDirectory);
+    }
+}
+
+TEST_F(FileUtilsTest, EnsureWritable)
+{
+    {
+        // Existent file should be writable
+        auto res = ensure_writable(ExistentFile, OutMode);
+        EXPECT_TRUE(res.has_value());
+    }
+    {
+        // Non existent file should be readable and parent dirs created
+        auto parent_dir = NonExistentFile.parent_path();
+        EXPECT_FALSE(std::filesystem::exists(parent_dir));
+
+        auto res = ensure_writable(NonExistentFile, OutMode);
+        EXPECT_TRUE(res.has_value());
+        EXPECT_TRUE(std::filesystem::exists(parent_dir));
+
+        // Cleanup
+        rm(parent_dir, true);
+    }
+    {
+        // Existent file with bad mode should NOT be writable
+        auto res = ensure_writable(ExistentFile, InMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::BadMode);
+    }
+    {
+        // Existent dir should NOT be writable
+        auto res = ensure_writable(ExistentDir, OutMode);
+        EXPECT_FALSE(res.has_value());
+        EXPECT_EQ(res.error().type, FileError::Type::IsDirectory);
+    }
+}
+
+TEST_F(FileUtilsTest, StreamSize)
+{
+    {
+        std::ifstream stream(ExistentFile);
+        auto size = stream_size(stream);
+        EXPECT_EQ(size, 0);
+    }
+    {
+        auto file_path = NonExistentFile;
+        auto res       = ensure_parent_dir(file_path);
+        EXPECT_TRUE(res.has_value());
+
+        std::uintmax_t expected_size = 256;
+        touch(file_path, expected_size);
+        EXPECT_TRUE(std::filesystem::exists(file_path));
+        EXPECT_EQ(std::filesystem::file_size(file_path), expected_size);
+
+        std::ifstream stream(file_path);
+        auto size = stream_size(stream);
+        EXPECT_EQ(size, expected_size);
+    }
+}

--- a/tests/helpers/file_fixtures.cpp
+++ b/tests/helpers/file_fixtures.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file file_fixtures.cpp
+ * @brief File fixtures for unit tests.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#include "helpers/file_fixtures.h"
+
+#include <filesystem>
+#include <fstream>
+#include <ios>
+
+void FileTest::mkdir(const std::filesystem::path& dir)
+{
+    if (!std::filesystem::exists(dir)) {
+        std::filesystem::create_directories(dir);
+    }
+}
+
+void FileTest::rmdir(const std::filesystem::path& dir)
+{
+    if (std::filesystem::exists(dir) && std::filesystem::is_directory(dir) &&
+        std::filesystem::is_empty(dir)) {
+        std::filesystem::remove(dir);
+    }
+}
+
+void FileTest::rm(const std::filesystem::path& path, bool recursive)
+{
+    if (std::filesystem::exists(path)) {
+        if (recursive) {
+            std::filesystem::remove_all(path);
+        }
+        else if (std::filesystem::is_regular_file(path)) {
+            std::filesystem::remove(path);
+        }
+    }
+}
+
+void FileTest::touch(const std::filesystem::path& path, size_t size)
+{
+    if (!std::filesystem::exists(path)) {
+        std::ofstream file(path, std::ios::out | std::ios::binary);
+        if (size > 0) {
+            file.seekp(static_cast<std::streamoff>(size - 1));
+            file.write("", 1);
+        }
+    }
+}

--- a/tests/helpers/file_fixtures.h
+++ b/tests/helpers/file_fixtures.h
@@ -1,0 +1,42 @@
+/**
+ * @file file_fixtures.h
+ * @brief File fixtures for unit tests.
+ *
+ * @license GPLv3 (see LICENSE file)
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <filesystem>
+
+class FileTest : public ::testing::Test {
+protected:
+    static constexpr auto InMode                              = std::ios::in;
+    static constexpr auto OutMode                             = std::ios::out;
+    inline static const std::filesystem::path BaseDir         = "/tmp";
+    inline static const std::filesystem::path ExistentDir     = BaseDir / "existentdir";
+    inline static const std::filesystem::path ExistentFile    = ExistentDir / "existentfile.txt";
+    inline static const std::filesystem::path NonExistentDir  = BaseDir / "nonexistentdir";
+    inline static const std::filesystem::path NonExistentFile = NonExistentDir / "nonexistent.txt";
+
+    void SetUp() override
+    {
+        mkdir(ExistentDir);
+        touch(ExistentFile);
+    }
+
+    void TearDown() override
+    {
+        rm(NonExistentDir, true);
+        rm(ExistentDir, true);
+    }
+
+    // File helpers
+    static void mkdir(const std::filesystem::path& dir);
+    static void rmdir(const std::filesystem::path& dir);
+    static void rm(const std::filesystem::path& path, bool recursive = false);
+    static void touch(const std::filesystem::path& path, size_t size = 0);
+};

--- a/tests/helpers/rom_fixtures.h
+++ b/tests/helpers/rom_fixtures.h
@@ -44,7 +44,7 @@ struct ROMTest : public cpu::CpuTest {
 protected:
     static constexpr int LoopThreshold = 10000; // Arbitrary large number to prevent infinite loops
 
-    boyboy::core::cartridge::Cartridge cart;
+    std::unique_ptr<boyboy::core::cartridge::Cartridge> cart;
     boyboy::core::io::Io* io;
 
     SerialTestCapturer serial_capturer;

--- a/tests/mmu/test_mmu.cpp
+++ b/tests/mmu/test_mmu.cpp
@@ -73,7 +73,7 @@ TEST_F(MmuTest, MemoryRegionsRW)
 {
     // We don't test all regions in detail, just a few to verify read/write and mirroring
     // Some things to note:
-    //      - ROM and ERAM should return 0xFF because they aren't mapped to anything
+    //      - ROM and SRAM should return 0xFF because they aren't mapped to anything
     //      - IO registers have their own tests
     //      - NotUsable is always 0x00 on read and ignores writes
     //      - ROM is read-only
@@ -82,7 +82,7 @@ TEST_F(MmuTest, MemoryRegionsRW)
     //      - Reading from unmapped areas returns open bus value (last value on bus)
     //      - OAM is inaccessible during DMA transfer (ignores writes, reads return open bus)
     //      - Echo area's behavior is strange in DMG: with normal cartridge, mirrors WRAM,
-    //        but with some cartridges it mirrors WRAM AND ERAM; it writes to both and reads
+    //        but with some cartridges it mirrors WRAM AND SRAM; it writes to both and reads
     //        are a bitwise AND of both. We ignore this for now and just mirror WRAM0.
 
     // ROMBank0
@@ -103,12 +103,12 @@ TEST_F(MmuTest, MemoryRegionsRW)
     mmu.write_byte(VRAMStart, 0xAA);
     EXPECT_EQ(mmu.read_byte(VRAMStart), 0xAA) << "VRAM should be writable";
 
-    // ERAM
-    unmapped_val = mmu.read_byte(ERAMStart);
-    EXPECT_EQ(unmapped_val, OpenBusValue) << "Unmapped ERAM should read open bus value";
-    mmu.write_byte(ERAMStart, 0);
-    EXPECT_EQ(mmu.read_byte(ERAMStart), OpenBusValue)
-        << "Unmapped ERAM should read open bus value after write";
+    // SRAM
+    unmapped_val = mmu.read_byte(SRAMStart);
+    EXPECT_EQ(unmapped_val, OpenBusValue) << "Unmapped SRAM should read open bus value";
+    mmu.write_byte(SRAMStart, 0);
+    EXPECT_EQ(mmu.read_byte(SRAMStart), OpenBusValue)
+        << "Unmapped SRAM should read open bus value after write";
 
     // WRAM0
     mmu.write_byte(WRAM0Start, 0xCC);


### PR DESCRIPTION
## Summary

Implement battery-backed RAM save and load, as well as a new files module with centralized file handling.

## Added

**SRAM save and load:**
- `SaveManager` for handling save and load battery-backed RAM save files
- Save file loaded on start and saved on periodic intervals and on shutdown

**Files module:**
- `io` with streams, text and binary files read/write operations
- `paths`, `errors` and `utils` for shared files utilities
- `atomic_write` to prevent file corruption

**Config:**
- Battery configuration fields:
  - `saves.autosave` for enabling/disabling autosave
  - `saves.save_interval` for configuring autosave interval

**CLI:**
- Battery options for run command:
  - `--save-path` for custom saving path
  - `--autosave` for enabling/disabling autosave
  - `--save-interval` for setting autosave interval

## Changed

- `config_utils` and `CartridgeLoader` now use `files` module for files operations
- `CartridgeLoader` now returns a `unique_ptr` to `Cartridge`
- Rename `ERAM` to `SRAM`