### PR TITLE
Core issues fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- **Core** improvements:
+  - CPU halt bug emulation
+  - MMU VRAM and OAM lock on PPU access
 - **Files Module** with general file I/O handling and shared file paths and utilities
   - Text files read and write: `read_text()` and `write_text()`
   - Binary files read and write: `read_binary()` and `write_binary()`
@@ -30,10 +33,17 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Core `Timer` emulation more accurate and close to the real circuit
 - `config_utils` and `CartridgeLoader` now use `files` module for files operations
 - `CartridgeLoader` now returns a `unique_ptr` to `Cartridge`
 - Rename `ERAM` to `SRAM`
 - CLI and configuration improvements
+
+### Fixed
+
+- PPU missing LY on reset
+- Interrupt handler cycles not being factored
+- Mmu Not Usable (0xFEA0) region lock alongside OAM
 
 ---
 

--- a/config/asan_suppress.txt
+++ b/config/asan_suppress.txt
@@ -2,3 +2,4 @@
 leak:dbus_strdup
 leak:dbus_string_init_preallocated
 leak:dbus_connection_set_data
+leak:dbus_message_loader_queue_messages

--- a/include/boyboy/core/cpu/cpu.h
+++ b/include/boyboy/core/cpu/cpu.h
@@ -74,7 +74,7 @@ public:
     void set_ime(bool ime) { ime_ = ime; }
     void schedule_ime() { ime_scheduled_ = true; }
     [[nodiscard]] bool is_halted() const { return halted_; }
-    void set_halted(bool halted) { halted_ = halted; }
+    void set_halted(bool halted);
     [[nodiscard]] uint64_t get_cycles() const { return cycles_; }
     void set_cycles(uint64_t cycles) { cycles_ = cycles; }
     void add_cycles(uint8_t cycles) { cycles_ += cycles; }
@@ -124,6 +124,7 @@ private:
     bool ime_{false}; // Interrupt Master Enable flag
     bool ime_scheduled_{false};
     bool halted_{false};
+    bool halt_bug_{false};
 
     // Helper functions
     uint16_t fetch_n16()

--- a/include/boyboy/core/cpu/interrupt_handler.h
+++ b/include/boyboy/core/cpu/interrupt_handler.h
@@ -37,15 +37,16 @@ public:
     [[nodiscard]] bool is_enabled(uint8_t interrupt) const;
     [[nodiscard]] uint8_t pending() const;
 
+    [[nodiscard]] uint8_t get_ie() const;
+    [[nodiscard]] uint8_t get_if() const;
+
 private:
     Cpu& cpu_;
     mmu::Mmu& mmu_;
 
     void clear_interrupt(uint8_t interrupt);
 
-    [[nodiscard]] uint8_t get_ie() const;
     void set_ie(uint8_t value);
-    [[nodiscard]] uint8_t get_if() const;
     void set_if(uint8_t value);
 };
 

--- a/include/boyboy/core/cpu/interrupt_handler.h
+++ b/include/boyboy/core/cpu/interrupt_handler.h
@@ -30,7 +30,7 @@ public:
     InterruptHandler(InterruptHandler&&) = delete;
     InterruptHandler& operator=(InterruptHandler&&) = delete;
 
-    void service();
+    uint8_t service();
     void request(uint8_t interrupt);
     void enable(uint8_t interrupt);
     [[nodiscard]] bool is_requested(uint8_t interrupt) const;

--- a/include/boyboy/core/io/timer.h
+++ b/include/boyboy/core/io/timer.h
@@ -2,6 +2,9 @@
  * @file timer.h
  * @brief Timer operations for BoyBoy emulator.
  *
+ * For information on how the timer works check the implementation, Pan Docs and/or The
+ * Cycle-Accurate Game Boy Docs.
+ *
  * @license GPLv3 (see LICENSE file)
  */
 
@@ -9,6 +12,7 @@
 
 #include <array>
 #include <cstdint>
+#include <functional>
 
 #include "boyboy/core/io/iocomponent.h"
 
@@ -28,20 +32,30 @@ public:
     [[nodiscard]] bool is_stopped() const { return stopped_; }
 
     // Get timer frequency in number of cycles per increment
-    [[nodiscard]] uint16_t get_frequency() const
-    {
-        return Frequency::ClockFrequencies.at(tac_ & Flags::ClockSelectMask);
-    }
-    [[nodiscard]] static uint16_t get_frequency(uint8_t tac)
+    [[nodiscard]] uint16_t get_frequency() const { return get_frequency(tac_); }
+    [[nodiscard]] static constexpr uint16_t get_frequency(uint8_t tac)
     {
         return Frequency::ClockFrequencies.at(tac & Flags::ClockSelectMask);
     }
+
+    // Get the system counter test bit of the falling edge detector
+    // For internal use and testing
+    [[nodiscard]] uint16_t get_test_bit() const { return get_test_bit(tac_); }
+    [[nodiscard]] static constexpr uint16_t get_test_bit(uint8_t tac)
+    {
+        return DivBitLookup[tac & Flags::ClockSelectMask];
+    }
+
+    // Check if timer is enabled
+    [[nodiscard]] bool is_enabled() const { return is_enabled(tac_); }
+    [[nodiscard]] static bool is_enabled(uint8_t tac) { return (tac & Flags::TimerEnable) != 0; }
 
     struct Flags {
         static constexpr uint8_t ClockSelect0 = 0b001; // Bit 0 - Input Clock Select bit 0
         static constexpr uint8_t ClockSelect1 = 0b010; // Bit 1 - Input Clock Select bit 1
         static constexpr uint8_t TimerEnable = 0b100;  // Bit 2 - Timer Enable
         static constexpr uint8_t ClockSelectMask = ClockSelect0 | ClockSelect1;
+        static constexpr uint8_t TacMask = ClockSelectMask | TimerEnable;
 
         static constexpr uint8_t Clock256M = 0b00; // 4096 Hz
         static constexpr uint8_t Clock4M = 0b01;   // 262144 Hz
@@ -60,21 +74,129 @@ public:
         static constexpr std::array<uint16_t, 4> ClockFrequencies = {1024, 16, 64, 256};
     };
 
+    // Initial DIV values for DMG
+    static constexpr uint16_t DivCounterStartValue = 0xABCC;
+    static constexpr uint8_t DivStartValue = DivCounterStartValue >> 8;
+
+    // Internal system counter bit lookup table for the falling edge detector
+    static constexpr std::array<uint8_t, 4> DivBitLookup{9, 3, 5, 7};
+
+    // Delay in T-cycles for scheduled operations
+    static constexpr uint8_t InterruptDelay = 4;
+    static constexpr uint8_t TimaReloadDelay = 4;
+
 private:
     cpu::InterruptRequestCallback request_interrupt_;
 
     // Timer registers
-    uint8_t div_{0};  // Divider Register
     uint8_t tima_{0}; // Timer Counter
     uint8_t tma_{0};  // Timer Modulo
     uint8_t tac_{0};  // Timer Control
 
     // Internal counters
-    uint16_t div_counter_{0};
+    uint16_t div_counter_{DivCounterStartValue}; // Internal system counter
     uint16_t tima_counter_{0};
 
     // Timer stopped flag
     bool stopped_{false};
+
+    // TIMA overflow status
+    bool tima_overflow_{false};
+
+    // Schedulers for interrupt request and TIMA reload
+    struct Scheduler {
+        bool scheduled;
+        uint8_t remaining;
+        std::function<void(void)> execute;
+
+        void schedule(uint8_t delay)
+        {
+            scheduled = true;
+            remaining = delay;
+        }
+
+        void update(uint8_t cycles)
+        {
+            remaining -= std::min(remaining, cycles);
+            if (remaining == 0 && execute != nullptr) {
+                execute();
+                scheduled = false;
+            }
+        }
+
+        void reset()
+        {
+            scheduled = false;
+            remaining = 0;
+        }
+    };
+    Scheduler interrupt_scheduler_{
+        .scheduled = false,
+        .remaining = 0,
+        .execute = [this]() { request_interrupt_(cpu::Interrupts::Timer); },
+    };
+    Scheduler tima_reload_scheduler_{
+        .scheduled = false,
+        .remaining = 0,
+        .execute = [this]() { tima_ = tma_; },
+    };
+
+    void schedule_overflow()
+    {
+        interrupt_scheduler_.schedule(InterruptDelay);
+        tima_reload_scheduler_.schedule(InterruptDelay + TimaReloadDelay);
+        tima_overflow_ = false;
+    }
+
+    // Helpers for falling edge detection
+    [[nodiscard]] static bool is_test_bit_set(uint16_t div_counter, uint8_t tac)
+    {
+        return (div_counter & (1 << get_test_bit(tac))) != 0;
+    }
+    [[nodiscard]] static bool test_bit_status(uint16_t div_counter, uint8_t tac)
+    {
+        return is_test_bit_set(div_counter, tac) && is_enabled(tac);
+    }
+
+    // Falling edge handling
+    void handle_falling_edge(uint16_t old_div, uint16_t new_div, uint8_t old_tac, uint8_t new_tac)
+    {
+        bool prev_status = test_bit_status(old_div, old_tac);
+        bool new_status = test_bit_status(new_div, new_tac);
+        if (prev_status && !new_status) {
+            tima_++;
+            tima_overflow_ = tima_ == 0;
+        }
+    }
+
+    // Registers setters to allow falling edge detection
+    void increment_div_counter(uint16_t inc) { set_div_counter(div_counter_ + inc); }
+    void set_div_counter(uint16_t div_counter)
+    {
+        handle_falling_edge(div_counter_, div_counter, tac_, tac_);
+        div_counter_ = div_counter;
+    }
+    void set_tac(uint8_t tac)
+    {
+        tac &= Flags::TacMask;
+        handle_falling_edge(div_counter_, div_counter_, tac_, tac);
+        tac_ = tac;
+    }
+    void set_tima(uint8_t tima)
+    {
+        // If writing to TIMA while reload is scheduled but interrupt is already dispatched, write
+        // is ignored
+        if (tima_reload_scheduler_.scheduled && !interrupt_scheduler_.scheduled) {
+            return;
+        }
+        // If writing to TIMA while the interrupt is scheduled, it is canceled
+        if (interrupt_scheduler_.scheduled) {
+            interrupt_scheduler_.scheduled = false;
+            tima_reload_scheduler_.scheduled = false;
+        }
+        tima_ = tima;
+    }
+    void set_tma(uint8_t tma) { tma_ = tma; }
 };
 
 } // namespace boyboy::core::io

--- a/include/boyboy/core/mmu/mmu.h
+++ b/include/boyboy/core/mmu/mmu.h
@@ -216,8 +216,9 @@ private:
     // Memory region lock check
     [[nodiscard]] bool is_region_locked(MemoryRegionID region_id) const
     {
-        return (region_id == MemoryRegionID::VRAM && lock_vram_) ||
-               (region_id == MemoryRegionID::OAM && lock_oam_);
+        return (lock_vram_ && region_id == MemoryRegionID::VRAM) ||
+               (lock_oam_ &&
+                (region_id == MemoryRegionID::OAM || region_id == MemoryRegionID::NotUsable));
     }
 
     // I/O read/write handlers

--- a/src/boyboy/core/cpu/cpu.cpp
+++ b/src/boyboy/core/cpu/cpu.cpp
@@ -133,13 +133,14 @@ uint8_t Cpu::step()
 {
     BB_PROFILE_SCOPE(profiling::FrameTimer::Cpu);
 
-    interrupt_handler_.service();
+    uint8_t cycles = interrupt_handler_.service();
+    cycles_ += cycles;
 
     if (halted_) {
         // TODO: This should be 0 cycles, but until we have a clock, we use 4 cycles
         // to keep other components ticking
         cycles_ += 4;
-        return 4;
+        return cycles + 4;
     }
 
 #ifdef DISASSEMBLY_LOG
@@ -154,7 +155,7 @@ uint8_t Cpu::step()
         instr_type = InstructionType::CBPrefixed;
     }
 
-    uint8_t cycles = execute(opcode, instr_type);
+    cycles += execute(opcode, instr_type);
 
     // IME is enabled after the instruction following EI
     if (ime_scheduled_ &&

--- a/src/boyboy/core/cpu/instructions.cpp
+++ b/src/boyboy/core/cpu/instructions.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 
 #include "boyboy/common/errors.h"
+#include "boyboy/common/log/logging.h"
 #include "boyboy/common/utils.h"
 #include "boyboy/core/cpu/cpu.h"
 #include "boyboy/core/cpu/cpu_constants.h"
@@ -1177,6 +1178,14 @@ void Cpu::halt()
         // instruction, effectively causing the next instruction to be executed twice.
         // We won't enter halt mode, but we will continue execution normally.
         // Most ROMs will run a NOP after HALT to avoid the bug, so it will not be an issue.
+        halt_bug_ = true;
+
+        log::debug(
+            "CPU HALT bug triggered: IME={}, IE={}, IF={}",
+            get_ime(),
+            interrupt_handler_.get_ie(),
+            interrupt_handler_.get_if()
+        );
     }
 }
 // STOP

--- a/src/boyboy/core/emulator/emulator.cpp
+++ b/src/boyboy/core/emulator/emulator.cpp
@@ -39,9 +39,12 @@ void Emulator::start()
     log::info("Starting emulator...");
 
     // Hook system callbacks
+    // TODO: replace ppu callbacks with Mmu reference or better component system
     ppu_.set_mem_read_cb([this](uint16_t addr) { return mmu_->read_byte(addr); });
     ppu_.set_mem_write_cb([this](uint16_t addr, uint8_t value) { mmu_->write_byte(addr, value); });
     ppu_.set_dma_start_cb([this](uint8_t value) { mmu_->start_dma(value); });
+    ppu_.set_lock_vram_cb([this](bool lock) { mmu_->lock_vram(lock); });
+    ppu_.set_lock_oam_cb([this](bool lock) { mmu_->lock_oam(lock); });
     display_.set_button_cb([this](io::Button b, bool p) { on_button_event(b, p); });
     cartridge_->set_ram_load_cb([this]() {
         auto res = save::SaveManager::instance().load_sram(cartridge_->get_header().title);

--- a/src/boyboy/core/ppu/ppu.cpp
+++ b/src/boyboy/core/ppu/ppu.cpp
@@ -203,6 +203,7 @@ void Ppu::reset()
     frame_count_ = 0;
     window_line_counter_ = 0;
     set_mode(Mode::OAMScan);
+    set_ly(0);
 }
 
 void Ppu::set_ly(uint8_t ly)
@@ -247,9 +248,6 @@ void Ppu::set_mode(Mode new_mode)
     // Update STAT mode bits
     mode_ = new_mode;
     STAT_ = (STAT_ & ~registers::STAT::PPUModeMask) | static_cast<uint8_t>(mode_);
-
-    // Update LY=LYC flag
-    // update_lyc();
 
     check_interrupts();
 }

--- a/src/boyboy/core/ppu/ppu.cpp
+++ b/src/boyboy/core/ppu/ppu.cpp
@@ -197,13 +197,11 @@ void Ppu::reset()
     framebuffer_.fill(0);
     cycles_ = 0;
     cycles_in_mode_ = 0;
-    // mode_ = Mode::OAMScan;
     previous_mode_ = mode_;
     frame_ready_ = false;
     frame_count_ = 0;
     window_line_counter_ = 0;
-    set_mode(Mode::OAMScan);
-    set_ly(0);
+    enable_lcd(false);
 }
 
 void Ppu::set_ly(uint8_t ly)
@@ -248,6 +246,15 @@ void Ppu::set_mode(Mode new_mode)
     // Update STAT mode bits
     mode_ = new_mode;
     STAT_ = (STAT_ & ~registers::STAT::PPUModeMask) | static_cast<uint8_t>(mode_);
+
+    // Lock VRAM on mode 3 (Transfer)
+    if (lock_vram_cb_) {
+        lock_vram_cb_(mode_ == Mode::Transfer);
+    }
+    // Lock OAM on modes 2 and 3 (OAMScan and Transfer)
+    if (lock_oam_cb_) {
+        lock_oam_cb_(mode_ == Mode::OAMScan || mode_ == Mode::Transfer);
+    }
 
     check_interrupts();
 }

--- a/tests/io/test_timer.cpp
+++ b/tests/io/test_timer.cpp
@@ -7,9 +7,12 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 // boyboy
 #include "boyboy/core/cpu/interrupts.h"
 #include "boyboy/core/io/io.h"
+#include "boyboy/core/io/registers.h"
 #include "boyboy/core/io/timer.h"
 
 using boyboy::core::cpu::Interrupts;
@@ -23,116 +26,255 @@ protected:
     {
         io_.reset();
         timer_ = &io_.timer();
+
+        // Start with clean DIV counter (0)
+        reset_div();
     }
+
+    // Helpers because I'm feeling lazy
+    uint8_t read_reg(uint16_t reg) { return timer_->read(reg); }
+    void write_reg(uint16_t reg, uint8_t val) { timer_->write(reg, val); }
+    uint8_t read_div() { return read_reg(IoReg::Timer::DIV); }
+    uint8_t read_tima() { return read_reg(IoReg::Timer::TIMA); }
+    uint8_t read_tma() { return read_reg(IoReg::Timer::TMA); }
+    uint8_t read_tac() { return read_reg(IoReg::Timer::TAC); }
+    void reset_div() { write_reg(IoReg::Timer::DIV, 0xFF); }
+    void write_tima(uint8_t val) { write_reg(IoReg::Timer::TIMA, val); }
+    void write_tma(uint8_t val) { write_reg(IoReg::Timer::TMA, val); }
+    void write_tac(uint8_t val) { write_reg(IoReg::Timer::TAC, val); }
 
     Io io_;
     Timer* timer_;
+
+    static constexpr uint8_t Tma                 = 0xAB;
+    static constexpr uint8_t OverflowDelayCycles = Timer::InterruptDelay + Timer::TimaReloadDelay;
 };
+
+TEST_F(IoTimerTest, InitialState)
+{
+    timer_->reset();
+    EXPECT_EQ(read_div(), Timer::DivStartValue);
+    EXPECT_EQ(read_tima(), 0);
+    EXPECT_EQ(read_tma(), 0);
+    EXPECT_EQ(read_tac(), 0);
+}
+
+TEST_F(IoTimerTest, DivResetsOnWrite)
+{
+    reset_div(); // Writing any value resets DIV
+    EXPECT_EQ(read_div(), 0);
+
+    timer_->tick(Timer::Frequency::DivIncrement);
+    EXPECT_EQ(read_div(), 1);
+
+    reset_div();
+    EXPECT_EQ(read_div(), 0);
+}
 
 TEST_F(IoTimerTest, DivIncrements)
 {
-    // DIV should increment every 256 cycles
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 0);
+    // Ensure we start at 0
+    EXPECT_EQ(read_div(), 0);
 
+    // Tick until 1 left for increment
     timer_->tick(Timer::Frequency::DivIncrement - 1);
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 0);
+    EXPECT_EQ(read_div(), 0);
 
+    // Complete DIV period
     timer_->tick(1);
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 1);
+    EXPECT_EQ(read_div(), 1);
 
+    // Increase by 2
     timer_->tick(Timer::Frequency::DivIncrement * 2);
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 3);
+    EXPECT_EQ(read_div(), 3);
 }
 
 TEST_F(IoTimerTest, TimaIncrementsWhenEnabled)
 {
     // Set TAC to enable timer with 4096 Hz (1024 cycles per increment)
-    timer_->write(IoReg::Timer::TAC, Timer::Flags::TimerEnable | Timer::Flags::Clock256M);
-    timer_->write(IoReg::Timer::TIMA, 0);
-    timer_->write(IoReg::Timer::TMA, 0xAB);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0);
+    write_tac(Timer::Flags::TimerEnable | Timer::Flags::Clock256M);
+    write_tima(0);
+    write_tma(0xAB);
+    EXPECT_EQ(read_tima(), 0);
 
+    // Tick until 1 left for increment
     timer_->tick(Timer::Frequency::Tima256M - 1);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0);
+    EXPECT_EQ(read_tima(), 0);
 
+    // Complete TIMA period
     timer_->tick(1);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 1);
+    EXPECT_EQ(read_tima(), 1);
 
+    // Increase by 2
     timer_->tick(Timer::Frequency::Tima256M * 2);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 3);
+    EXPECT_EQ(read_tima(), 3);
 }
 
 TEST_F(IoTimerTest, TimaDoesNotIncrementWhenDisabled)
 {
     // Set TAC to disable timer
-    timer_->write(IoReg::Timer::TAC, Timer::Flags::Clock256M);
-    timer_->write(IoReg::Timer::TIMA, 0);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0);
+    write_tac(Timer::Flags::Clock256M);
+    write_tima(0);
+    EXPECT_EQ(read_tima(), 0);
 
     timer_->tick(Timer::Frequency::Tima256M * 4);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0);
+    EXPECT_EQ(read_tima(), 0);
 }
 
+// After TIMA overflows, we need 4 extra T-cycles to trigger the interrupt and another 4 to reload
+// TIMA with TMA
 TEST_F(IoTimerTest, TimaOverflowsToTma)
 {
     // Set TAC to enable timer with 4096 Hz (1024 cycles per increment)
-    timer_->write(IoReg::Timer::TAC, Timer::Flags::TimerEnable | Timer::Flags::Clock256M);
-    timer_->write(IoReg::Timer::TIMA, 0xFE);
-    timer_->write(IoReg::Timer::TMA, 0xAB);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0xFE);
+    write_tac(Timer::Flags::TimerEnable | Timer::Flags::Clock256M);
+    write_tima(0xFE);
+    write_tma(Tma);
+    EXPECT_EQ(read_tima(), 0xFE);
     EXPECT_FALSE(io_.read(IoReg::Interrupts::IF) & Interrupts::Timer);
 
+    // Increment TIMA to 0xFF
     timer_->tick(Timer::Frequency::Tima256M);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0xFF);
+    EXPECT_EQ(read_tima(), 0xFF);
     EXPECT_FALSE(io_.read(IoReg::Interrupts::IF) & Interrupts::Timer);
 
+    // Overflow TIMA, no interrupt or reload yet
     timer_->tick(Timer::Frequency::Tima256M);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0xAB); // Should overflow to TMA
+    EXPECT_EQ(read_tima(), 0);
+    EXPECT_FALSE(io_.read(IoReg::Interrupts::IF) & Interrupts::Timer);
+
+    // Advance 4 cycles, interrupt should be requested; no reload yet
+    timer_->tick(Timer::InterruptDelay);
+    EXPECT_EQ(read_tima(), 0);
+    EXPECT_TRUE(io_.read(IoReg::Interrupts::IF) & Interrupts::Timer);
+
+    // Advance 4 more cycles, interrupt should be still be requested and TIMA reloaded with TMA
+    timer_->tick(Timer::TimaReloadDelay);
+    EXPECT_EQ(read_tima(), Tma);
     EXPECT_TRUE(io_.read(IoReg::Interrupts::IF) & Interrupts::Timer);
 }
 
 TEST_F(IoTimerTest, TimaMultipleOverflows)
 {
-    // Set TAC to enable timer with 4096 Hz (1024 cycles per increment)
-    timer_->write(IoReg::Timer::TAC, Timer::Flags::TimerEnable | Timer::Flags::Clock256M);
-    timer_->write(IoReg::Timer::TIMA, 0xFF);
-    timer_->write(IoReg::Timer::TMA, 0xAB);
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0xFF);
-    EXPECT_FALSE(io_.read(IoReg::Interrupts::IF) & Interrupts::Timer);
+    int irq_count = 0;
+    timer_->set_interrupt_cb([&irq_count](uint8_t) { irq_count++; });
 
-    int count = 0;
-    timer_->set_interrupt_cb([&count](uint8_t) { count++; });
+    // Set TAC to enable timer with 4096 Hz (1024 cycles per increment)
+    write_tac(Timer::Flags::TimerEnable | Timer::Flags::Clock256M);
+    write_tima(0xFF);
+    write_tma(Tma);
+    EXPECT_EQ(read_tima(), 0xFF);
 
     // Tick enough cycles to cause multiple overflows
-    timer_->tick(Timer::Frequency::Tima256M); // 1 increment, should overflow
-    timer_->write(IoReg::Timer::TIMA, 0xFF); // Set TIMA to 0xFF to cause overflow on next increment
-    timer_->tick(Timer::Frequency::Tima256M * 5);          // 5 increments, should overflow once
-    EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0xAB + 4); // Should overflow to TMA and increment
-    EXPECT_EQ(count, 2); // Interrupt should have been requested twice
+    timer_->tick(Timer::Frequency::Tima256M + OverflowDelayCycles); // 1 increment, should overflow
+    write_tima(0xFF); // Set TIMA to 0xFF to cause overflow on next increment
+    timer_->tick(Timer::Frequency::Tima256M * 5); // 5 increments, should overflow once
+    EXPECT_EQ(read_tima(), 0xAB + 4);             // Should overflow to TMA and increment
+    EXPECT_EQ(irq_count, 2);                      // Interrupt should have been requested twice
+}
+
+// Edge conditions for TIMA overflow
+TEST_F(IoTimerTest, TimaOverflowEdgeCases)
+{
+    int irq_count = 0;
+    timer_->set_interrupt_cb([&irq_count](uint8_t) { irq_count++; });
+
+    // Initial timer conditions
+    auto init_timer = [&]() {
+        timer_->reset();
+        irq_count = 0;
+        reset_div();
+        write_tac(Timer::Flags::TimerEnable | Timer::Flags::Clock4M);
+        write_tima(0xFF);
+        write_tma(Tma);
+    };
+
+    // Writing TIMA during the first 4 delay cycles should cancel interrupt and reload
+    {
+        init_timer();
+
+        // Tick until overflow happens
+        timer_->tick(timer_->get_frequency());
+        EXPECT_EQ(read_tima(), 0);
+        EXPECT_EQ(irq_count, 0);
+
+        // Write TIMA during delay
+        write_tima(0xFF);
+        EXPECT_EQ(read_tima(), 0xFF);
+        EXPECT_EQ(irq_count, 0);
+
+        // Advance delay period, nothing should happen
+        timer_->tick(OverflowDelayCycles);
+        EXPECT_EQ(read_tima(), 0xFF);
+        EXPECT_EQ(irq_count, 0);
+    }
+
+    // Writing TIMA during the second 4 delay cycles should ignore write
+    {
+        init_timer();
+
+        // Tick until overflow happens
+        timer_->tick(timer_->get_frequency());
+        EXPECT_EQ(read_tima(), 0);
+        EXPECT_EQ(irq_count, 0);
+
+        // Tick first delay cycle, interrupt should be triggered
+        timer_->tick(Timer::InterruptDelay);
+        EXPECT_EQ(read_tima(), 0);
+        EXPECT_EQ(irq_count, 1);
+
+        // Write TIMA during second delay, nothing should happen
+        write_tima(0xFF);
+        EXPECT_EQ(read_tima(), 0);
+        EXPECT_EQ(irq_count, 1);
+
+        // Advance second delay period, TIMA should reload with TMA
+        timer_->tick(Timer::TimaReloadDelay);
+        EXPECT_EQ(read_tima(), Tma);
+        EXPECT_EQ(irq_count, 1);
+    }
+
+    // Writing TMA during the second 4 delay cycles should load new TMA value
+    {
+        constexpr auto NewTma = static_cast<uint8_t>(~Tma);
+
+        init_timer();
+
+        // Tick until overflow happens
+        timer_->tick(timer_->get_frequency());
+        EXPECT_EQ(read_tima(), 0);
+        EXPECT_EQ(irq_count, 0);
+
+        // Tick first delay cycle, interrupt should be triggered
+        timer_->tick(Timer::InterruptDelay);
+        EXPECT_EQ(read_tima(), 0);
+        EXPECT_EQ(irq_count, 1);
+
+        // Write new TMA during second delay
+        write_tma(NewTma);
+        EXPECT_EQ(read_tima(), 0);
+        EXPECT_EQ(irq_count, 1);
+
+        // Advance second delay period, TIMA should reload with the new TMA
+        timer_->tick(Timer::TimaReloadDelay);
+        EXPECT_EQ(read_tima(), NewTma);
+        EXPECT_EQ(irq_count, 1);
+    }
 }
 
 TEST_F(IoTimerTest, TimaFrequencySettings)
 {
     for (uint8_t tac = 0; tac <= 0b11; ++tac) {
-        timer_->write(IoReg::Timer::TAC, tac | Timer::Flags::TimerEnable);
-        timer_->write(IoReg::Timer::TIMA, 0);
-        EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0);
+        write_tac(tac | Timer::Flags::TimerEnable);
+        write_tima(0);
+        reset_div();
+        EXPECT_EQ(read_tima(), 0);
 
         timer_->tick(Timer::get_frequency(tac) - 1);
-        EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 0);
+        EXPECT_EQ(read_tima(), 0);
 
         timer_->tick(1);
-        EXPECT_EQ(timer_->read(IoReg::Timer::TIMA), 1);
+        EXPECT_EQ(read_tima(), 1);
     }
-}
-
-TEST_F(IoTimerTest, DivResetsOnWrite)
-{
-    timer_->write(IoReg::Timer::DIV, 0xFF); // Writing any value resets DIV
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 0);
-
-    timer_->tick(Timer::Frequency::DivIncrement);
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 1);
 }
 
 TEST_F(IoTimerTest, StartStop)
@@ -140,17 +282,190 @@ TEST_F(IoTimerTest, StartStop)
     // Initially timer is running
     EXPECT_FALSE(timer_->is_stopped());
     timer_->tick(Timer::Frequency::DivIncrement);
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 1);
+    EXPECT_EQ(read_div(), 1);
 
     // Stop the timer
     timer_->stop();
     EXPECT_TRUE(timer_->is_stopped());
     timer_->tick(Timer::Frequency::DivIncrement * 5);
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 0); // DIV is reset and should not increment
+    EXPECT_EQ(read_div(), 0); // DIV is reset and should not increment
 
     // Start the timer again
     timer_->start();
     EXPECT_FALSE(timer_->is_stopped());
     timer_->tick(Timer::Frequency::DivIncrement);
-    EXPECT_EQ(timer_->read(IoReg::Timer::DIV), 1); // DIV should increment again
+    EXPECT_EQ(read_div(), 1); // DIV should increment again
+}
+
+// Timer obscure behaviour tests.
+// The following tests are consequences of how the timer hardware circuit works.
+// Basically, TIMA is incremented with the falling edge of an AND between TAC enable and certain
+// bits of the internal system counter based on TAC selected frequency. This means two things:
+//     1) Any change in DIV, TAC.enable or TAC.freq that triggers the falling edge detector, will
+//     increase TIMA. i.e. TAC.enable && DIV(TAC.freq) 1 -> 0; TIMA++
+//     2) If resetting DIV before the tested bit is set, TIMA will never be incremented no matter
+//     how many ticks.
+// For more information check Timer implementation, Pan Docs and/or TCAGBD.
+
+// If the DIV register is resetted at a rate higher than TIMA clock, TIMA won't increase.
+// This is only true if DIV reset frequency is higher than double of TIMA clock, because the tested
+// bit is never set.
+TEST_F(IoTimerTest, TimaResetWithDivReset)
+{
+    // Set TIMA clock to 16 T-cycles
+    write_tac(Timer::Flags::TimerEnable | Timer::Flags::Clock4M);
+    EXPECT_EQ(read_tima(), 0);
+
+    // Tick enough to not increase TIMA
+    auto cycles = (1 << timer_->get_test_bit()) - 1;
+    timer_->tick(cycles);
+    EXPECT_EQ(read_tima(), 0);
+
+    // Reset DIV and tick again, which would increment TIMA if it were independent from DIV
+    reset_div();
+    timer_->tick(cycles);
+    EXPECT_EQ(read_tima(), 0);
+
+    // Repeat the same for all frequencies several times in a loop
+    for (int clk = 0; clk <= 0b11; ++clk) {
+        write_tac(Timer::Flags::TimerEnable | clk);
+        auto test_bit   = timer_->get_test_bit();
+        auto clk_cycles = (1 << test_bit) - 1;
+
+        // Loop for an arbitrary N
+        for (int n = 10; n > 0; --n) {
+            auto acc_cycles = 0;
+
+            reset_div();
+            write_tima(0);
+
+            // Repeat tick-reset-tick pattern
+            timer_->tick(clk_cycles);
+            acc_cycles += clk_cycles;
+            EXPECT_EQ(read_tima(), 0);
+
+            reset_div();
+            timer_->tick(clk_cycles);
+            acc_cycles += clk_cycles;
+            EXPECT_EQ(read_tima(), 0);
+
+            // Check that accumulated cycles should have triggered TIMA
+            EXPECT_LE(1 << test_bit, acc_cycles);
+        }
+    }
+
+    // Reset again and tick just enough to complete one TIMA increment
+    reset_div();
+    timer_->tick(timer_->get_frequency());
+    EXPECT_EQ(read_tima(), 1);
+}
+
+// If the DIV tested bit for TIMA falls from 1 to 0 because of a DIV write, TIMA WILL increment
+TEST_F(IoTimerTest, TimaIncWithDivReset)
+{
+    // Set clock and get test bit of the system counter
+    constexpr auto Clock   = Timer::Flags::Clock4M;
+    constexpr auto TestBit = Timer::get_test_bit(Clock);
+    write_tac(Timer::Flags::TimerEnable | Clock);
+
+    // Tick timer until system counter has test bit set and ensure we have valid TIMA
+    timer_->tick(1 << TestBit);
+    EXPECT_EQ(read_tima(), 0);
+
+    // Reset DIV, TIMA should increment because of the falling-edge detection
+    reset_div();
+    EXPECT_EQ(read_div(), 0);
+    EXPECT_EQ(read_tima(), 1);
+
+    // Repeat for all clocks
+    for (auto clk = 0; clk <= Timer::Flags::ClockSelectMask; ++clk) {
+        // Reset state
+        write_tac(Timer::Flags::TimerEnable | clk);
+        reset_div();
+        write_tima(0);
+
+        // Tick
+        auto test_bit = Timer::get_test_bit(clk);
+        auto cycles   = 1 << test_bit;
+        timer_->tick(cycles);
+        EXPECT_EQ(read_tima(), 0);
+
+        // Reset div
+        reset_div();
+        EXPECT_EQ(read_tima(), 1);
+    }
+}
+
+// If a frequency change would cause to trigger the falling edge detector, TIMA should increment
+TEST_F(IoTimerTest, TimaIncWithFreqChange)
+{
+    // Increase the internal system counter up to the tested bit, then change to a frequency for
+    // which tested bit is 0 to trigger the falling edge detector
+
+    // Set clock and get test bit of the system counter
+    constexpr auto Clock   = Timer::Flags::Clock4M;
+    constexpr auto TestBit = Timer::get_test_bit(Clock);
+    write_tac(Timer::Flags::TimerEnable | Clock);
+
+    // Tick timer until system counter has test bit set and ensure we have valid DIV and TIMA
+    timer_->tick(1 << TestBit);
+    EXPECT_EQ(read_div(), 0);
+    EXPECT_EQ(read_tima(), 0);
+
+    // Now set a clock that tests a different bit. That bit should be 0 and TIMA should increment
+    write_tac(Timer::Flags::TimerEnable | ((Clock + 1) & Timer::Flags::ClockSelectMask));
+    EXPECT_EQ(read_tima(), 1);
+
+    // Repeat for all clocks
+    for (int clk = 1; clk < 4; ++clk) {
+        // Reset state
+        write_tac(Timer::Flags::TimerEnable | Clock);
+        reset_div();
+        write_tima(0);
+
+        // Tick and switch clock
+        timer_->tick(1 << TestBit);
+        write_tac(Timer::Flags::TimerEnable | ((Clock + clk) & Timer::Flags::ClockSelectMask));
+        EXPECT_EQ(read_tima(), 1);
+    }
+}
+
+// If a timer disable change would cause to trigger the falling edge detector, TIMA should increment
+TEST_F(IoTimerTest, TimaIncWithTimerDisable)
+{
+    // Increase the internal system counter up to the tested bit, then disable the timer to trigger
+    // the falling edge detector
+
+    // Set clock and get test bit of the system counter
+    constexpr auto Clock   = Timer::Flags::Clock4M;
+    constexpr auto TestBit = Timer::get_test_bit(Clock);
+    write_tac(Timer::Flags::TimerEnable | Clock);
+
+    // Tick timer until system counter has test bit set and ensure we have valid DIV and TIMA
+    timer_->tick(1 << TestBit);
+    EXPECT_EQ(read_div(), 0);
+    EXPECT_EQ(read_tima(), 0);
+
+    // Disable timer to trigger detector, TIMA should increment
+    write_tac(Clock);
+    EXPECT_EQ(read_tima(), 1);
+
+    // Repeat for all clocks
+    for (auto clk = 0; clk <= Timer::Flags::ClockSelectMask; ++clk) {
+        // Reset state
+        write_tac(Timer::Flags::TimerEnable | clk);
+        reset_div();
+        write_tima(0);
+
+        // Tick
+        auto test_bit = Timer::get_test_bit(clk);
+        auto cycles   = 1 << test_bit;
+        timer_->tick(cycles);
+        EXPECT_EQ(read_tima(), 0);
+
+        // Disable timer
+        write_tac(clk);
+        EXPECT_EQ(read_tima(), 1) << "TIMA should be incremented after disable for " << cycles
+                                  << " cycles with clock " << clk;
+    }
 }

--- a/tests/mmu/test_mmu.cpp
+++ b/tests/mmu/test_mmu.cpp
@@ -195,7 +195,7 @@ TEST_F(MmuTest, RegionLock)
     mmu.reset();
     EXPECT_FALSE(mmu.is_vram_locked());
     EXPECT_FALSE(mmu.is_oam_locked());
-    
+
     mmu.write_byte(VRAMStart, TestByte);
     mmu.write_byte(OAMStart, TestByte);
     EXPECT_EQ(mmu.read_byte(VRAMStart), TestByte);

--- a/tests/mmu/test_mmu.cpp
+++ b/tests/mmu/test_mmu.cpp
@@ -164,6 +164,7 @@ TEST_F(MmuTest, RegionLock)
     mmu.write_byte(OAMStart, TestByte);
     EXPECT_EQ(mmu.read_byte(VRAMStart), TestByte);
     EXPECT_EQ(mmu.read_byte(OAMStart), TestByte);
+    EXPECT_EQ(mmu.read_byte(NotUsableStart), 0);
 
     // Should lock correctly
     mmu.lock_vram(true);
@@ -174,10 +175,12 @@ TEST_F(MmuTest, RegionLock)
     // Should read openbus while locked
     EXPECT_EQ(mmu.read_byte(VRAMStart), OpenBusValue);
     EXPECT_EQ(mmu.read_byte(OAMStart), OpenBusValue);
+    EXPECT_EQ(mmu.read_byte(NotUsableStart), OpenBusValue);
 
     // Should read normally if unrestricted
     EXPECT_EQ(mmu.read_byte(VRAMStart, true), TestByte);
     EXPECT_EQ(mmu.read_byte(OAMStart, true), TestByte);
+    EXPECT_EQ(mmu.read_byte(NotUsableStart, true), 0);
 
     // Should not write while locked
     mmu.write_byte(VRAMStart, 0);

--- a/tests/mmu/test_mmu.cpp
+++ b/tests/mmu/test_mmu.cpp
@@ -150,3 +150,54 @@ TEST_F(MmuTest, MemoryRegionsRW)
     mmu.write_byte(IEAddr, 0x44);
     EXPECT_EQ(mmu.read_byte(IEAddr), 0x44) << "IEReg should be writable";
 }
+
+TEST_F(MmuTest, RegionLock)
+{
+    const uint8_t TestByte = 0xAA;
+
+    // Regions should be unlocked at start
+    EXPECT_FALSE(mmu.is_vram_locked());
+    EXPECT_FALSE(mmu.is_oam_locked());
+
+    // Should be able to read and write normally while unlocked
+    mmu.write_byte(VRAMStart, TestByte);
+    mmu.write_byte(OAMStart, TestByte);
+    EXPECT_EQ(mmu.read_byte(VRAMStart), TestByte);
+    EXPECT_EQ(mmu.read_byte(OAMStart), TestByte);
+
+    // Should lock correctly
+    mmu.lock_vram(true);
+    mmu.lock_oam(true);
+    EXPECT_TRUE(mmu.is_vram_locked());
+    EXPECT_TRUE(mmu.is_oam_locked());
+
+    // Should read openbus while locked
+    EXPECT_EQ(mmu.read_byte(VRAMStart), OpenBusValue);
+    EXPECT_EQ(mmu.read_byte(OAMStart), OpenBusValue);
+
+    // Should read normally if unrestricted
+    EXPECT_EQ(mmu.read_byte(VRAMStart, true), TestByte);
+    EXPECT_EQ(mmu.read_byte(OAMStart, true), TestByte);
+
+    // Should not write while locked
+    mmu.write_byte(VRAMStart, 0);
+    mmu.write_byte(OAMStart, 0);
+    EXPECT_EQ(mmu.read_byte(VRAMStart, true), TestByte);
+    EXPECT_EQ(mmu.read_byte(OAMStart, true), TestByte);
+
+    // Should write normally if unrestricted
+    mmu.write_byte(VRAMStart, 0, true);
+    mmu.write_byte(OAMStart, 0, true);
+    EXPECT_EQ(mmu.read_byte(VRAMStart, true), 0);
+    EXPECT_EQ(mmu.read_byte(OAMStart, true), 0);
+
+    // After reset should be unlocked
+    mmu.reset();
+    EXPECT_FALSE(mmu.is_vram_locked());
+    EXPECT_FALSE(mmu.is_oam_locked());
+    
+    mmu.write_byte(VRAMStart, TestByte);
+    mmu.write_byte(OAMStart, TestByte);
+    EXPECT_EQ(mmu.read_byte(VRAMStart), TestByte);
+    EXPECT_EQ(mmu.read_byte(OAMStart), TestByte);
+}


### PR DESCRIPTION
## Summary

Attempt to solve several known core issues to make the emulator more accurate.

## Added

- CPU halt bug emulation
- MMU VRAM and OAM lock on PPU access

## Changed

- TImer emulation more accurate and close to the real circuit

## Fixed

- PPU missing LY on reset
- Interrupt handler cycles not being factored
- Mmu Not Usable (0xFEA0) region lock alongside OAM